### PR TITLE
[feat] #66 - 상점 상품 조회 api 구현 및 상품주인여부 반환 로직 추가

### DIFF
--- a/src/main/java/com/napzak/domain/interest/core/InterestRepository.java
+++ b/src/main/java/com/napzak/domain/interest/core/InterestRepository.java
@@ -20,7 +20,7 @@ public interface InterestRepository extends JpaRepository<InterestEntity, Long> 
 
 	@Query("SELECT i.productId " +
 		"FROM InterestEntity i " +
-		"WHERE i.productId IN :productIds AND i.productId = :storeId")
+		"WHERE i.productId IN :productIds AND i.storeId = :storeId")
 	List<Long> findLikedProductIdsByStore(@Param("productIds") List<Long> productIds,
 		@Param("storeId") Long storeId);
 

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -68,7 +69,7 @@ public class ProductController {
 
 		// 4. 응답 생성
 		ProductSellListResponse response = ProductSellListResponse.from(
-			parsedSortOption, pagination, interestMap, genreMap
+			parsedSortOption, pagination, interestMap, genreMap, storeId
 		);
 
 		// 5. 응답 반환
@@ -105,7 +106,7 @@ public class ProductController {
 		Map<Long, String> genreMap = fetchGenreMap(pagination);
 
 		ProductBuyListResponse response = ProductBuyListResponse.from(
-			parsedSortOption, pagination, interestMap, genreMap
+			parsedSortOption, pagination, interestMap, genreMap, storeId
 		);
 
 		return ResponseEntity.ok(
@@ -145,7 +146,7 @@ public class ProductController {
 		Map<Long, String> genreMap = fetchGenreMap(pagination);
 
 		ProductSellListResponse response = ProductSellListResponse.from(
-			parsedSortOption, pagination, interestMap, genreMap
+			parsedSortOption, pagination, interestMap, genreMap, storeId
 		);
 
 		return ResponseEntity.ok(
@@ -183,7 +184,85 @@ public class ProductController {
 		Map<Long, String> genreMap = fetchGenreMap(pagination);
 
 		ProductBuyListResponse response = ProductBuyListResponse.from(
-			parsedSortOption, pagination, interestMap, genreMap
+			parsedSortOption, pagination, interestMap, genreMap, storeId
+		);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(
+				ProductSuccessCode.PRODUCT_LIST_RETRIEVE_SUCCESS,
+				response
+			)
+		);
+	}
+
+	@GetMapping("sell/store/{storeOwnerId}")
+	public ResponseEntity<SuccessResponse<ProductSellListResponse>> getStoreSellProducts(
+		@RequestParam(defaultValue = "RECENT") String sortOption,
+		@RequestParam(defaultValue = "false") Boolean isOnSale,
+		@RequestParam(defaultValue = "false") Boolean isUnopened,
+		@RequestParam(required = false) List<Long> genreId,
+		@RequestParam(required = false) String cursor,
+		@RequestParam(defaultValue = "10") int size,
+		@PathVariable Long storeOwnerId,
+		@CurrentMember Long currentStoreId
+	) {
+		SortOption parsedSortOption = parseSortOption(sortOption);
+		CursorValues cursorValues = parseCursorValues(cursor, parsedSortOption);
+
+		ProductPagination pagination = productService.getStoreSellProducts(
+			storeOwnerId,
+			parsedSortOption,
+			cursorValues.getCursorProductId(),
+			cursorValues.getCursorOptionalValue(),
+			size,
+			isOnSale,
+			isUnopened,
+			genreId
+		);
+
+		Map<Long, Boolean> interestMap = fetchInterestMap(pagination, currentStoreId);
+		Map<Long, String> genreMap = fetchGenreMap(pagination);
+
+		ProductSellListResponse response = ProductSellListResponse.from(
+			parsedSortOption, pagination, interestMap, genreMap, currentStoreId
+		);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(
+				ProductSuccessCode.PRODUCT_LIST_RETRIEVE_SUCCESS,
+				response
+			)
+		);
+	}
+
+	@GetMapping("/buy/store/{storeOwnerId}")
+	public ResponseEntity<SuccessResponse<ProductBuyListResponse>> getStoreBuyProducts(
+		@RequestParam(defaultValue = "RECENT") String sortOption,
+		@RequestParam(defaultValue = "false") Boolean isOnSale,
+		@RequestParam(required = false) List<Long> genreId,
+		@RequestParam(required = false) String cursor,
+		@RequestParam(defaultValue = "10") int size,
+		@PathVariable Long storeOwnerId,
+		@CurrentMember Long currentStoreId
+	) {
+		SortOption parsedSortOption = parseSortOption(sortOption);
+		CursorValues cursorValues = parseCursorValues(cursor, parsedSortOption);
+
+		ProductPagination pagination = productService.getStoreBuyProducts(
+			storeOwnerId,
+			parsedSortOption,
+			cursorValues.getCursorProductId(),
+			cursorValues.getCursorOptionalValue(),
+			size,
+			isOnSale,
+			genreId
+		);
+
+		Map<Long, Boolean> interestMap = fetchInterestMap(pagination, currentStoreId);
+		Map<Long, String> genreMap = fetchGenreMap(pagination);
+
+		ProductBuyListResponse response = ProductBuyListResponse.from(
+			parsedSortOption, pagination, interestMap, genreMap, currentStoreId
 		);
 
 		return ResponseEntity.ok(

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyDto.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyDto.java
@@ -14,7 +14,8 @@ public record ProductBuyDto(
 	boolean isInterested,
 	TradeType tradeType,
 	TradeStatus tradeStatus,
-	boolean isPriceNegotiable
+	boolean isPriceNegotiable,
+	boolean isOwnedByCurrentUser
 ) {
 	// ProductWithFirstPhoto에서 genreName을 외부에서 전달받는 메서드
 	public static ProductBuyDto from(
@@ -22,7 +23,8 @@ public record ProductBuyDto(
 		String firstPhoto,
 		String uploadTime,
 		boolean isInterested,
-		String genreName
+		String genreName,
+		boolean isOwnedByCurrentUser
 	) {
 		return new ProductBuyDto(
 			product.getId(),
@@ -34,7 +36,8 @@ public record ProductBuyDto(
 			isInterested,
 			product.getTradeType(),
 			product.getTradeStatus(),
-			product.isPriceNegotiable()
+			product.isPriceNegotiable(),
+			isOwnedByCurrentUser
 		);
 	}
 
@@ -49,11 +52,12 @@ public record ProductBuyDto(
 		boolean isInterested,
 		TradeType tradeType,
 		TradeStatus tradeStatus,
-		boolean isPriceNegotiable
+		boolean isPriceNegotiable,
+		boolean isOwnedByCurrentUser
 	) {
 		return new ProductBuyDto(
 			productId, genreName, productName, photo, price, uploadTime, isInterested,
-			tradeType, tradeStatus, isPriceNegotiable
+			tradeType, tradeStatus, isPriceNegotiable, isOwnedByCurrentUser
 		);
 	}
 }

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyListResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyListResponse.java
@@ -18,17 +18,19 @@ public record ProductBuyListResponse(
 		SortOption sortOption,
 		ProductPagination pagination,
 		Map<Long, Boolean> interestMap,
-		Map<Long, String> genreMap
+		Map<Long, String> genreMap,
+		Long currentStoreId
 	) {
 		// 1. DTO 생성
 		List<ProductBuyDto> productDtos = pagination.getProductList().stream()
 			.map(product -> {
 				String uploadTime = TimeUtils.calculateUploadTime(product.getCreatedAt());
 				boolean isInterested = interestMap.getOrDefault(product.getId(), false);
-				String genreName = genreMap.getOrDefault(product.getGenreId(), "기타"); // genreName 매핑
+				String genreName = genreMap.getOrDefault(product.getGenreId(), "기타");
+				boolean isOwnedByCurrentUser = currentStoreId.equals(product.getStoreId());
 
 				return ProductBuyDto.from(
-					product, product.getFirstPhoto(), uploadTime, isInterested, genreName
+					product, product.getFirstPhoto(), uploadTime, isInterested, genreName, isOwnedByCurrentUser
 				);
 			}).toList();
 

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellDto.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellDto.java
@@ -13,7 +13,8 @@ public record ProductSellDto(
 	String uploadTime,
 	boolean isInterested,
 	TradeType tradeType,
-	TradeStatus tradeStatus
+	TradeStatus tradeStatus,
+	boolean isOwnedByCurrentUser
 ) {
 	// ProductWithFirstPhoto에서 genreName을 외부에서 전달받는 메서드
 	public static ProductSellDto from(
@@ -21,7 +22,8 @@ public record ProductSellDto(
 		String firstPhoto,
 		String uploadTime,
 		boolean isInterested,
-		String genreName
+		String genreName,
+		boolean isOwnedByCurrentUser
 	) {
 		return new ProductSellDto(
 			product.getId(),
@@ -32,7 +34,8 @@ public record ProductSellDto(
 			uploadTime,
 			isInterested,
 			product.getTradeType(),
-			product.getTradeStatus()
+			product.getTradeStatus(),
+			isOwnedByCurrentUser
 		);
 	}
 
@@ -46,10 +49,11 @@ public record ProductSellDto(
 		String uploadTime,
 		boolean isInterested,
 		TradeType tradeType,
-		TradeStatus tradeStatus
+		TradeStatus tradeStatus,
+		boolean isOwnedByCurrentUser
 	) {
 		return new ProductSellDto(
-			productId, genreName, productName, photo, price, uploadTime, isInterested, tradeType, tradeStatus
+			productId, genreName, productName, photo, price, uploadTime, isInterested, tradeType, tradeStatus, isOwnedByCurrentUser
 		);
 	}
 }

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellListResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellListResponse.java
@@ -18,17 +18,19 @@ public record ProductSellListResponse(
 		SortOption sortOption,
 		ProductPagination pagination,
 		Map<Long, Boolean> interestMap,
-		Map<Long, String> genreMap // 추가
+		Map<Long, String> genreMap,
+		Long currentStoreId
 	) {
 		// 1. DTO 생성
 		List<ProductSellDto> productDtos = pagination.getProductList().stream()
 			.map(product -> {
 				String uploadTime = TimeUtils.calculateUploadTime(product.getCreatedAt());
 				boolean isInterested = interestMap.getOrDefault(product.getId(), false);
-				String genreName = genreMap.getOrDefault(product.getGenreId(), "기타"); // genreName 매핑
+				String genreName = genreMap.getOrDefault(product.getGenreId(), "기타");
+				boolean isOwnedByCurrentUser = currentStoreId.equals(product.getStoreId());
 
 				return ProductSellDto.from(
-					product, product.getFirstPhoto(), uploadTime, isInterested, genreName
+					product, product.getFirstPhoto(), uploadTime, isInterested, genreName, isOwnedByCurrentUser
 				);
 			}).toList();
 

--- a/src/main/java/com/napzak/domain/product/api/service/ProductService.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductService.java
@@ -73,6 +73,32 @@ public class ProductService {
 		);
 	}
 
+	public ProductPagination getStoreSellProducts(
+		Long storeId, SortOption sortOption, Long cursorProductId, Integer cursorOptionalValue,
+		int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds) {
+
+		return retrieveAndPreparePagination(
+			() -> productRetriever.retrieveStoreProducts(
+				storeId, sortOption, cursorProductId, cursorOptionalValue, size,
+				isOnSale, isUnopened, genreIds, TradeType.SELL
+			),
+			size
+		);
+	}
+
+	public ProductPagination getStoreBuyProducts(
+		Long storeId, SortOption sortOption, Long cursorProductId, Integer cursorOptionalValue,
+		int size, Boolean isOnSale, List<Long> genreIds) {
+
+		return retrieveAndPreparePagination(
+			() -> productRetriever.retrieveStoreProducts(
+				storeId, sortOption, cursorProductId, cursorOptionalValue, size,
+				isOnSale, null, genreIds, TradeType.BUY
+			),
+			size
+		);
+	}
+
 	private ProductPagination retrieveAndPreparePagination(
 		ProductRetrieval retrievalLogic,
 		int size

--- a/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustom.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustom.java
@@ -14,4 +14,8 @@ public interface ProductRepositoryCustom {
 	List<ProductEntity> searchProductsBySearchWordAndSortOptionAndFilters(
 		String searchWord, OrderSpecifier<?> orderSpecifier, Long cursorProductId, Integer cursorOptionalValue, int size,
 		Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType);
+
+	List<ProductEntity> findProductsByStoreIdAndSortOptionAndFilters(
+		Long storeId, OrderSpecifier<?> orderSpecifier, Long cursorProductId, Integer cursorOptionalValue,
+		int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType);
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
@@ -41,6 +41,19 @@ public class ProductRetriever {
 	}
 
 	@Transactional(readOnly = true)
+	public List<Product> retrieveStoreProducts(
+		Long storeId, SortOption sortOption, Long cursorProductId, Integer cursorOptionalValue,
+		int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType) {
+
+		return productRepository.findProductsByStoreIdAndSortOptionAndFilters(
+				storeId, sortOption.toOrderSpecifier(), cursorProductId, cursorOptionalValue, size,
+				isOnSale, isUnopened, genreIds, tradeType
+			).stream()
+			.map(Product::fromEntity)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
 	public List<Product> searchProducts(
 		String searchWord, SortOption sortOption, Long cursorProductId, Integer cursorOptionalValue, int size,
 		Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType) {

--- a/src/main/java/com/napzak/domain/product/core/vo/ProductWithFirstPhoto.java
+++ b/src/main/java/com/napzak/domain/product/core/vo/ProductWithFirstPhoto.java
@@ -19,10 +19,11 @@ public class ProductWithFirstPhoto {
 	private final TradeType tradeType;
 	private final TradeStatus tradeStatus;
 	private final boolean isPriceNegotiable;
+	private final Long storeId;
 
 	private ProductWithFirstPhoto(Long id, String title, int price, int interestCount,
-		LocalDateTime createdAt, String firstPhoto, Long genreId,
-		TradeType tradeType, TradeStatus tradeStatus, boolean isPriceNegotiable) {
+		LocalDateTime createdAt, String firstPhoto, Long genreId, TradeType tradeType,
+		TradeStatus tradeStatus, boolean isPriceNegotiable, Long storeId) {
 		this.id = id;
 		this.title = title;
 		this.price = price;
@@ -33,6 +34,7 @@ public class ProductWithFirstPhoto {
 		this.tradeType = tradeType;
 		this.tradeStatus = tradeStatus;
 		this.isPriceNegotiable = isPriceNegotiable;
+		this.storeId = storeId;
 	}
 
 	public static ProductWithFirstPhoto from(Product product, String firstPhoto) {
@@ -46,7 +48,8 @@ public class ProductWithFirstPhoto {
 			product.getGenreId(),
 			product.getTradeType(),
 			product.getTradeStatus(),
-			product.getIsPriceNegotiable()
+			product.getIsPriceNegotiable(),
+			product.getStoreId()
 		);
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #66 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 상점 팔아요 상품 조회 api 구현
- 상점 구해요 상품 조회 api 구현
- 상품주인여부 반환 로직 추가 : 기획의 요구사항 변경에 따라 각각의 상품이 접속한 현재 유저의 상품인지 여부를 상품정보와 함께 반환하도록 바꿨습니다. 상품리스트 반환 관련 response dto 쪽 확인해주시면 됩니다!
- 좋아요 여부가 제대로 조회되지 않는 이슈가 있었는데, 쿼리문이 잘못 커밋됐던 것으로 보입니다.. 다시 수정해두었습니다!

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### 상점 팔아요 상품 조회 api 구현
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/f3001ef1-c59d-4b91-a48c-338d1dc7ad0e" />
정상적으로 조회되며 필터링도 잘됩니다.
isOwnedByCurrentUser도 잘 반환됩니다.

<img width="1292" alt="image" src="https://github.com/user-attachments/assets/92eeeed0-776c-4009-9a46-3dd16ebea740" />
내 상점을 조회했을 경우 isOwnedByCurrentUser가 true인 것을 확인했습니다.

### 상점 구해요 상품 조회 api 구현
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/5f2df736-472e-426d-9bf8-f1eb600c1a74" />
정상적으로 조회되며 필터링도 잘됩니다.
isOwnedByCurrentUser도 잘 반환됩니다.

### 상품주인여부 반환 로직 추가
<img width="433" alt="image" src="https://github.com/user-attachments/assets/8898104b-a36f-40dc-bcc7-4dcd06d9c036" />
<img width="437" alt="image" src="https://github.com/user-attachments/assets/1da0c5e3-df90-4549-9976-6df7d7eb6df4" />
<img width="425" alt="image" src="https://github.com/user-attachments/assets/2fb9171d-a8cb-43b3-b34d-65ff25236569" />
<img width="424" alt="image" src="https://github.com/user-attachments/assets/341046a2-9f34-4235-925e-e82cb9a9bd2d" />
탐색탭에서도 isOwnedByCurrentUser이 같이 반환되는 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
