### PR TITLE
[refactor] #68 - 엔티티 연관관계 제거

### DIFF
--- a/src/main/java/com/napzak/domain/chat/core/entity/ChatMessageEntity.java
+++ b/src/main/java/com/napzak/domain/chat/core/entity/ChatMessageEntity.java
@@ -1,6 +1,5 @@
 package com.napzak.domain.chat.core.entity;
 
-import com.napzak.domain.store.core.entity.StoreEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,55 +16,32 @@ import static com.napzak.domain.chat.core.entity.ChatMessageTableConstants.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessageEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = COLUMN_ID)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = COLUMN_ID)
+	private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = COLUMN_CHAT_ROOM_ID, nullable = false)
-    private ChatRoomEntity chatRoomEntity;
+	@Column(name = COLUMN_CHAT_ROOM_ID, nullable = false)
+	private Long chatRoomId;
 
-    @Column(name = COLUMN_CONTENT, nullable = false)
-    private String content;
+	@Column(name = COLUMN_CONTENT, nullable = false)
+	private String content;
 
-    @Column(name = COLUMN_CREATED_AT, nullable = false)
-    private LocalDateTime createdAt;
+	@Column(name = COLUMN_CREATED_AT, nullable = false)
+	private LocalDateTime createdAt;
 
-    @Column(name = COLUMN_IS_READ, nullable = false)
-    private Boolean isRead;
+	@Column(name = COLUMN_IS_READ, nullable = false)
+	private Boolean isRead;
 
-    @ManyToOne
-    @JoinColumn(name = COLUMN_SENDER_ID, nullable = false)
-    private StoreEntity sender;
+	@Column(name = COLUMN_SENDER_ID, nullable = false)
+	private Long senderId;
 
-    @Builder
-    private ChatMessageEntity(ChatRoomEntity chatRoomEntity, String content, LocalDateTime createdAt, Boolean isRead, StoreEntity sender) {
-        this.chatRoomEntity = chatRoomEntity;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.isRead = isRead;
-        this.sender = sender;
-    }
-
-    public static ChatMessageEntity create(
-            final ChatRoomEntity chatRoomEntity,
-            final String content,
-            final LocalDateTime createdAt,
-            final Boolean isRead, StoreEntity sender
-    ) {
-        return ChatMessageEntity.builder()
-                .chatRoomEntity(chatRoomEntity)
-                .content(content)
-                .createdAt(createdAt)
-                .isRead(isRead)
-                .sender(sender)
-                .build();
-    }
-
-    public Boolean getIsRead() {
-        return isRead;
-    }
-
-
+	@Builder
+	private ChatMessageEntity(Long chatRoomId, String content, LocalDateTime createdAt, Boolean isRead, Long senderId) {
+		this.chatRoomId = chatRoomId;
+		this.content = content;
+		this.createdAt = createdAt;
+		this.isRead = isRead;
+		this.senderId = senderId;
+	}
 }

--- a/src/main/java/com/napzak/domain/chat/core/entity/ChatRoomEntity.java
+++ b/src/main/java/com/napzak/domain/chat/core/entity/ChatRoomEntity.java
@@ -1,7 +1,5 @@
 package com.napzak.domain.chat.core.entity;
 
-import com.napzak.domain.product.core.entity.ProductEntity;
-import com.napzak.domain.store.core.entity.StoreEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,33 +27,19 @@ public class ChatRoomEntity {
     @Column(name = COLUMN_UPDATED_AT, nullable = false)
     private LocalDateTime updatedAt = LocalDateTime.now();
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = COLUMN_PRODUCT_ID, nullable = false)
-    private ProductEntity productEntity;
+    @Column(name = COLUMN_PRODUCT_ID, nullable = false)
+    private Long productId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = COLUMN_OWNER_ID, nullable = false)
-    private StoreEntity owner;
+    @Column(name = COLUMN_OWNER_ID, nullable = false)
+    private Long ownerId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = COLUMN_REQUESTER_ID, nullable = false)
-    private StoreEntity requester;
+    @Column(name = COLUMN_REQUESTER_ID, nullable = false)
+    private Long requesterId;
 
     @Builder
-    private ChatRoomEntity(ProductEntity productEntity, StoreEntity owner, StoreEntity requester) {
-        this.productEntity = productEntity;
-        this.owner = owner;
-        this.requester = requester;
-    }
-
-    public static ChatRoomEntity create(
-            final ProductEntity productEntity,
-            final StoreEntity owner,
-            final StoreEntity requester) {
-        return ChatRoomEntity.builder()
-                .productEntity(productEntity)
-                .owner(owner)
-                .requester(requester)
-                .build();
+    private ChatRoomEntity(Long productId, Long ownerId, Long requesterId) {
+        this.productId = productId;
+        this.ownerId = ownerId;
+        this.requesterId = requesterId;
     }
 }

--- a/src/main/java/com/napzak/domain/chat/core/vo/ChatMessage.java
+++ b/src/main/java/com/napzak/domain/chat/core/vo/ChatMessage.java
@@ -1,39 +1,38 @@
 package com.napzak.domain.chat.core.vo;
 
 import com.napzak.domain.chat.core.entity.ChatMessageEntity;
-import com.napzak.domain.store.core.entity.StoreEntity;
+
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class ChatMessage {
-    private final Long id;
-    private final ChatRoom chatRoom;
-    private final String content;
-    private final LocalDateTime createdAt;
-    private final boolean isRead;
-    private final StoreEntity sender;
+	private final Long id;
+	private final Long chatRoomId;
+	private final String content;
+	private final LocalDateTime createdAt;
+	private final boolean isRead;
+	private final Long senderId;
 
-    public ChatMessage(Long id, ChatRoom chatRoom, String content, LocalDateTime createdAt, boolean isRead, StoreEntity sender) {
-        this.id = id;
-        this.chatRoom = chatRoom;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.isRead = isRead;
-        this.sender = sender;
-    }
+	public ChatMessage(Long id, Long chatRoomId, String content, LocalDateTime createdAt, boolean isRead,
+		Long senderId) {
+		this.id = id;
+		this.chatRoomId = chatRoomId;
+		this.content = content;
+		this.createdAt = createdAt;
+		this.isRead = isRead;
+		this.senderId = senderId;
+	}
 
-    public static ChatMessage fromEntity(ChatMessageEntity chatMessageEntity) {
-        return new ChatMessage(
-                chatMessageEntity.getId(),
-                ChatRoom.fromEntity(chatMessageEntity.getChatRoomEntity()),
-                chatMessageEntity.getContent(),
-                chatMessageEntity.getCreatedAt(),
-                chatMessageEntity.getIsRead(),
-                chatMessageEntity.getSender()
-        );
-    }
-
-
+	public static ChatMessage fromEntity(ChatMessageEntity chatMessageEntity) {
+		return new ChatMessage(
+			chatMessageEntity.getId(),
+			chatMessageEntity.getChatRoomId(),
+			chatMessageEntity.getContent(),
+			chatMessageEntity.getCreatedAt(),
+			chatMessageEntity.getIsRead(),
+			chatMessageEntity.getSenderId()
+		);
+	}
 }

--- a/src/main/java/com/napzak/domain/chat/core/vo/ChatRoom.java
+++ b/src/main/java/com/napzak/domain/chat/core/vo/ChatRoom.java
@@ -1,38 +1,38 @@
 package com.napzak.domain.chat.core.vo;
 
 import com.napzak.domain.chat.core.entity.ChatRoomEntity;
-import com.napzak.domain.product.core.entity.ProductEntity;
-import com.napzak.domain.store.core.entity.StoreEntity;
+
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class ChatRoom {
-    private final Long id;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime updatedAt;
-    private final ProductEntity productEntity;
-    private final StoreEntity owner;
-    private final StoreEntity requester;
+	private final Long id;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+	private final Long productId;
+	private final Long ownerId;
+	private final Long requesterId;
 
-    public ChatRoom(Long id, LocalDateTime createdAt, LocalDateTime updatedAt, ProductEntity productEntity, StoreEntity owner, StoreEntity requester) {
-        this.id = id;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.productEntity = productEntity;
-        this.owner = owner;
-        this.requester = requester;
-    }
+	public ChatRoom(Long id, LocalDateTime createdAt, LocalDateTime updatedAt, Long productId, Long ownerId,
+		Long requesterId) {
+		this.id = id;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+		this.productId = productId;
+		this.ownerId = ownerId;
+		this.requesterId = requesterId;
+	}
 
-    public static ChatRoom fromEntity(ChatRoomEntity chatRoomEntity) {
-        return new ChatRoom(
-                chatRoomEntity.getId(),
-                chatRoomEntity.getCreatedAt(),
-                chatRoomEntity.getUpdatedAt(),
-                chatRoomEntity.getProductEntity(),
-                chatRoomEntity.getOwner(),
-                chatRoomEntity.getRequester()
-        );
-    }
+	public static ChatRoom fromEntity(ChatRoomEntity chatRoomEntity) {
+		return new ChatRoom(
+			chatRoomEntity.getId(),
+			chatRoomEntity.getCreatedAt(),
+			chatRoomEntity.getUpdatedAt(),
+			chatRoomEntity.getProductId(),
+			chatRoomEntity.getOwnerId(),
+			chatRoomEntity.getRequesterId()
+		);
+	}
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoRepository.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoRepository.java
@@ -11,13 +11,13 @@ import com.napzak.domain.product.core.entity.ProductPhotoEntity;
 
 @Repository
 public interface ProductPhotoRepository extends JpaRepository<ProductPhotoEntity, Long> {
-	@Query("SELECT p.productEntity.id AS productId, p.photoUrl AS photoUrl " +
+	@Query("SELECT p.productId AS productId, p.photoUrl AS photoUrl " +
 		"FROM ProductPhotoEntity p " +
-		"WHERE p.sequence = 1 AND p.productEntity.id IN :productIds")
+		"WHERE p.sequence = 1 AND p.productId IN :productIds")
 	List<Object[]> findFirstPhotosByProductIds(@Param("productIds") List<Long> productIds);
 
 	@Query("SELECT p FROM ProductPhotoEntity p " +
-		"WHERE p.productEntity.id = :productId " +
+		"WHERE p.productId = :productId " +
 		"ORDER BY p.sequence ASC")
 	List<ProductPhotoEntity> findAllByProductEntityOrderBySequenceAsc(@Param("productId") Long productId);
 

--- a/src/main/java/com/napzak/domain/product/core/entity/ProductHashtagEntity.java
+++ b/src/main/java/com/napzak/domain/product/core/entity/ProductHashtagEntity.java
@@ -14,32 +14,30 @@ import static com.napzak.domain.product.core.entity.ProductHashtagTableConstants
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductHashtagEntity {
 
-    @Id
-    @Column(name = COLUMN_ID)
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@Column(name = COLUMN_ID)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = COLUMN_PRODUCT_ID, nullable = false)
-    private ProductEntity productEntity;
+	@Column(name = COLUMN_PRODUCT_ID, nullable = false)
+	private Long productId;
 
-    @ManyToOne
-    @JoinColumn(name = COLUMN_HASHTAG_ID, nullable = false)
-    private HashtagEntity hashtagEntity;
+	@Column(name = COLUMN_HASHTAG_ID, nullable = false)
+	private Long hashtagId;
 
-    @Builder
-    private ProductHashtagEntity(ProductEntity productEntity, HashtagEntity hashtagEntity) {
-        this.productEntity = productEntity;
-        this.hashtagEntity = hashtagEntity;
-    }
+	@Builder
+	private ProductHashtagEntity(Long productId, Long hashtagId) {
+		this.productId = productId;
+		this.hashtagId = hashtagId;
+	}
 
-    public static ProductHashtagEntity create(
-            final ProductEntity productEntity,
-            final HashtagEntity hashtagEntity
-    ) {
-        return ProductHashtagEntity.builder()
-                .productEntity(productEntity)
-                .hashtagEntity(hashtagEntity)
-                .build();
-    }
+	public static ProductHashtagEntity create(
+		final Long productId,
+		final Long hashtagId
+	) {
+		return ProductHashtagEntity.builder()
+			.productId(productId)
+			.hashtagId(hashtagId)
+			.build();
+	}
 }

--- a/src/main/java/com/napzak/domain/product/core/entity/ProductPhotoEntity.java
+++ b/src/main/java/com/napzak/domain/product/core/entity/ProductPhotoEntity.java
@@ -14,39 +14,37 @@ import static com.napzak.domain.product.core.entity.ProductPhotoTableConstants.*
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductPhotoEntity {
 
-    @Id
-    @Column(name = COLUMN_ID)
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@Column(name = COLUMN_ID)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = COLUMN_PRODUCT_ID, nullable = false)
-    private ProductEntity productEntity;
+	@Column(name = COLUMN_PRODUCT_ID, nullable = false)
+	private Long productId;
 
-    @Column(name = COLUMN_PHOTO_URL, nullable = false)
-    private String photoUrl;
+	@Column(name = COLUMN_PHOTO_URL, nullable = false)
+	private String photoUrl;
 
-    @Column(name = COLUMN_SEQUENCE, nullable = false)
-    private int sequence;
+	@Column(name = COLUMN_SEQUENCE, nullable = false)
+	private int sequence;
 
-    @Builder
-    private ProductPhotoEntity(Long id, ProductEntity productEntity, String photoUrl, int sequence) {
-        this.id = id;
-        this.productEntity = productEntity;
-        this.photoUrl = photoUrl;
-        this.sequence = sequence;
-    }
+	@Builder
+	private ProductPhotoEntity(Long id, Long productId, String photoUrl, int sequence) {
+		this.id = id;
+		this.productId = productId;
+		this.photoUrl = photoUrl;
+		this.sequence = sequence;
+	}
 
-    public static ProductPhotoEntity create(
-            final ProductEntity productEntity,
-            final String photoUrl,
-            final int sequence
-    ) {
-        return ProductPhotoEntity.builder()
-                .productEntity(productEntity)
-                .photoUrl(photoUrl)
-                .sequence(sequence)
-                .build();
-    }
-
+	public static ProductPhotoEntity create(
+		final Long productId,
+		final String photoUrl,
+		final int sequence
+	) {
+		return ProductPhotoEntity.builder()
+			.productId(productId)
+			.photoUrl(photoUrl)
+			.sequence(sequence)
+			.build();
+	}
 }

--- a/src/main/java/com/napzak/domain/product/core/vo/ProductHashtag.java
+++ b/src/main/java/com/napzak/domain/product/core/vo/ProductHashtag.java
@@ -1,25 +1,26 @@
 package com.napzak.domain.product.core.vo;
 
 import com.napzak.domain.product.core.entity.ProductHashtagEntity;
+
 import lombok.Getter;
 
 @Getter
 public class ProductHashtag {
-    private final Long id;
-    private final Product product;
-    private final Hashtag hashtag;
+	private final Long id;
+	private final Long productId;
+	private final Long hashtagId;
 
-    public ProductHashtag(Long id, Product product,  Hashtag hashtag) {
-        this.id = id;
-        this.product = product;
-        this.hashtag = hashtag;
-    }
+	public ProductHashtag(Long id, Long productId, Long hashtagId) {
+		this.id = id;
+		this.productId = productId;
+		this.hashtagId = hashtagId;
+	}
 
-    public static ProductHashtag fromEntity(ProductHashtagEntity productHashtagEntity) {
-        return new ProductHashtag(
-                productHashtagEntity.getId(),
-                Product.fromEntity(productHashtagEntity.getProductEntity()),
-                Hashtag.fromEntity(productHashtagEntity.getHashtagEntity())
-        );
-    }
+	public static ProductHashtag fromEntity(ProductHashtagEntity productHashtagEntity) {
+		return new ProductHashtag(
+			productHashtagEntity.getId(),
+			productHashtagEntity.getProductId(),
+			productHashtagEntity.getHashtagId()
+		);
+	}
 }

--- a/src/main/java/com/napzak/domain/product/core/vo/ProductPhoto.java
+++ b/src/main/java/com/napzak/domain/product/core/vo/ProductPhoto.java
@@ -1,28 +1,29 @@
 package com.napzak.domain.product.core.vo;
 
 import com.napzak.domain.product.core.entity.ProductPhotoEntity;
+
 import lombok.Getter;
 
 @Getter
 public class ProductPhoto {
-    private final Long id;
-    private final Product product;
-    private final String photoUrl;
-    private final int sequence;
+	private final Long id;
+	private final Long productId;
+	private final String photoUrl;
+	private final int sequence;
 
-    public ProductPhoto(Long id, Product product, String photoUrl, int sequence) {
-        this.id = id;
-        this.product = product;
-        this.photoUrl = photoUrl;
-        this.sequence = sequence;
-    }
+	public ProductPhoto(Long id, Long productId, String photoUrl, int sequence) {
+		this.id = id;
+		this.productId = productId;
+		this.photoUrl = photoUrl;
+		this.sequence = sequence;
+	}
 
-    public static ProductPhoto fromEntity(ProductPhotoEntity productPhotoEntity) {
-        return new ProductPhoto(
-                productPhotoEntity.getId(),
-                Product.fromEntity(productPhotoEntity.getProductEntity()),
-                productPhotoEntity.getPhotoUrl(),
-                productPhotoEntity.getSequence()
-        );
-    }
+	public static ProductPhoto fromEntity(ProductPhotoEntity productPhotoEntity) {
+		return new ProductPhoto(
+			productPhotoEntity.getId(),
+			productPhotoEntity.getProductId(),
+			productPhotoEntity.getPhotoUrl(),
+			productPhotoEntity.getSequence()
+		);
+	}
 }

--- a/src/main/java/com/napzak/domain/review/core/entity/ReviewEntity.java
+++ b/src/main/java/com/napzak/domain/review/core/entity/ReviewEntity.java
@@ -1,7 +1,5 @@
 package com.napzak.domain.review.core.entity;
 
-import com.napzak.domain.product.core.entity.ProductEntity;
-import com.napzak.domain.store.core.entity.StoreEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,63 +16,38 @@ import static com.napzak.domain.review.core.entity.ReviewTableConstants.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReviewEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = COLUMN_ID)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = COLUMN_ID)
+	private Long id;
 
-    @Column(name = COLUMN_RATE, nullable = false)
-    private int rate;
+	@Column(name = COLUMN_RATE, nullable = false)
+	private int rate;
 
-    @Column(name = COLUMN_COMMENT, nullable = false)
-    private String comment;
+	@Column(name = COLUMN_COMMENT, nullable = false)
+	private String comment;
 
-    @Column(name = COLUMN_CREATED_AT, nullable = false)
-    private final LocalDateTime createdAt = LocalDateTime.now();
+	@Column(name = COLUMN_CREATED_AT, nullable = false)
+	private final LocalDateTime createdAt = LocalDateTime.now();
 
-    @Column(name = COLUMN_UPDATED_AT, nullable = false)
-    private LocalDateTime updatedAt = LocalDateTime.now();
+	@Column(name = COLUMN_UPDATED_AT, nullable = false)
+	private LocalDateTime updatedAt = LocalDateTime.now();
 
-    @ManyToOne
-    @JoinColumn(name = COLUMN_PRODUCT_ID, nullable = false)
-    private ProductEntity productEntity;
+	@Column(name = COLUMN_PRODUCT_ID, nullable = false)
+	private Long productId;
 
-    @ManyToOne
-    @JoinColumn(name = COLUMN_REVIEWER_ID, nullable = false)
-    private StoreEntity reviewer;
+	@Column(name = COLUMN_REVIEWER_ID, nullable = false)
+	private Long reviewerId;
 
-    @ManyToOne
-    @JoinColumn(name = COLUMN_REVIEWEE_ID, nullable = false)
-    private StoreEntity reviewee;
+	@Column(name = COLUMN_REVIEWEE_ID, nullable = false)
+	private Long revieweeId;
 
-    @Builder
-    private ReviewEntity(
-            int rate,
-            String comment,
-            ProductEntity productEntity,
-            StoreEntity reviewer,
-            StoreEntity reviewee
-    ) {
-        this.rate = rate;
-        this.comment = comment;
-        this.productEntity = productEntity;
-        this.reviewer = reviewer;
-        this.reviewee = reviewee;
-    }
-
-    public static ReviewEntity create(
-            final int rate,
-            final String comment,
-            final ProductEntity productEntity,
-            final StoreEntity reviewer,
-            final StoreEntity reviewee
-    ) {
-        return ReviewEntity.builder()
-                .rate(rate)
-                .comment(comment)
-                .productEntity(productEntity)
-                .reviewer(reviewer)
-                .reviewee(reviewee)
-                .build();
-    }
+	@Builder
+	private ReviewEntity(int rate, String comment, Long productId, Long reviewerId, Long revieweeId) {
+		this.rate = rate;
+		this.comment = comment;
+		this.productId = productId;
+		this.reviewerId = reviewerId;
+		this.revieweeId = revieweeId;
+	}
 }

--- a/src/main/java/com/napzak/domain/review/core/vo/Review.java
+++ b/src/main/java/com/napzak/domain/review/core/vo/Review.java
@@ -1,44 +1,44 @@
 package com.napzak.domain.review.core.vo;
 
-import com.napzak.domain.product.core.vo.Product;
 import com.napzak.domain.review.core.entity.ReviewEntity;
-import com.napzak.domain.store.core.vo.Store;
+
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class Review {
-    private final Long id;
-    private final int rate;
-    private final String comment;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime updatedAt;
-    private final Product product;
-    private final Store reviewer;
-    private final Store reviewee;
+	private final Long id;
+	private final int rate;
+	private final String comment;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+	private final Long productId;
+	private final Long reviewerId;
+	private final Long revieweeId;
 
-    public Review(Long id, int rate, String comment, LocalDateTime createdAt, LocalDateTime updatedAt, Product product, Store reviewer, Store reviewee) {
-        this.id = id;
-        this.rate = rate;
-        this.comment = comment;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.product = product;
-        this.reviewer = reviewer;
-        this.reviewee = reviewee;
-    }
+	public Review(Long id, int rate, String comment, LocalDateTime createdAt, LocalDateTime updatedAt,
+		Long productId, Long reviewerId, Long revieweeId) {
+		this.id = id;
+		this.rate = rate;
+		this.comment = comment;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+		this.productId = productId;
+		this.reviewerId = reviewerId;
+		this.revieweeId = revieweeId;
+	}
 
-    public static Review fromEntity(ReviewEntity reviewEntity){
-        return new Review(
-                reviewEntity.getId(),
-                reviewEntity.getRate(),
-                reviewEntity.getComment(),
-                reviewEntity.getCreatedAt(),
-                reviewEntity.getUpdatedAt(),
-                Product.fromEntity(reviewEntity.getProductEntity()),
-                Store.fromEntity(reviewEntity.getReviewer()),
-                Store.fromEntity(reviewEntity.getReviewee())
-        );
-    }
+	public static Review fromEntity(ReviewEntity reviewEntity) {
+		return new Review(
+			reviewEntity.getId(),
+			reviewEntity.getRate(),
+			reviewEntity.getComment(),
+			reviewEntity.getCreatedAt(),
+			reviewEntity.getUpdatedAt(),
+			reviewEntity.getProductId(),
+			reviewEntity.getReviewerId(),
+			reviewEntity.getRevieweeId()
+		);
+	}
 }

--- a/src/main/java/com/napzak/domain/store/core/entity/GenrePreferenceEntity.java
+++ b/src/main/java/com/napzak/domain/store/core/entity/GenrePreferenceEntity.java
@@ -1,7 +1,5 @@
 package com.napzak.domain.store.core.entity;
 
-import com.napzak.domain.genre.core.entity.GenreEntity;
-
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,39 +8,26 @@ import lombok.NoArgsConstructor;
 
 import static com.napzak.domain.store.core.entity.GenrePreferenceTableConstants.*;
 
-
 @Entity
 @Table(name = TABLE_GENRE_PREFERENCE)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GenrePreferenceEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = COLUMN_GENRE_PREFERENCE_ID)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = COLUMN_GENRE_PREFERENCE_ID)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = COLUMN_STORE_ID, nullable = false)
-    private StoreEntity storeEntity;
+	@Column(name = COLUMN_STORE_ID, nullable = false)
+	private Long storeId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = COLUMN_GENRE_ID, nullable = false)
-    private GenreEntity genreEntity;
+	@Column(name = COLUMN_GENRE_ID, nullable = false)
+	private Long genreId;
 
-    @Builder
-    private GenrePreferenceEntity(StoreEntity storeEntity, GenreEntity genreEntity) {
-        this.storeEntity = storeEntity;
-        this.genreEntity = genreEntity;
-    }
-
-    public static GenrePreferenceEntity create(
-            final StoreEntity storeEntity,
-            final GenreEntity genreEntity
-    ) {
-        return GenrePreferenceEntity.builder()
-                .storeEntity(storeEntity)
-                .genreEntity(genreEntity)
-                .build();
-    }
+	@Builder
+	private GenrePreferenceEntity(Long storeId, Long genreId) {
+		this.storeId = storeId;
+		this.genreId = genreId;
+	}
 }

--- a/src/main/java/com/napzak/domain/store/core/vo/GenrePreference.java
+++ b/src/main/java/com/napzak/domain/store/core/vo/GenrePreference.java
@@ -1,26 +1,26 @@
 package com.napzak.domain.store.core.vo;
 
-import com.napzak.domain.genre.core.vo.Genre;
 import com.napzak.domain.store.core.entity.GenrePreferenceEntity;
+
 import lombok.Getter;
 
 @Getter
 public class GenrePreference {
-    private final Long id;
-    private final Store store;
-    private final Genre genre;
+	private final Long id;
+	private final Long storeId;
+	private final Long genreId;
 
-    public GenrePreference(Long id, Store store, Genre genre) {
-        this.id = id;
-        this.store = store;
-        this.genre = genre;
-    }
+	public GenrePreference(Long id, Long storeId, Long genreId) {
+		this.id = id;
+		this.storeId = storeId;
+		this.genreId = genreId;
+	}
 
-    public static GenrePreference fromEntity(GenrePreferenceEntity genrePreferenceEntity) {
-        return new GenrePreference(
-                genrePreferenceEntity.getId(),
-                Store.fromEntity(genrePreferenceEntity.getStoreEntity()),
-                Genre.fromEntity(genrePreferenceEntity.getGenreEntity())
-        );
-    }
+	public static GenrePreference fromEntity(GenrePreferenceEntity genrePreferenceEntity) {
+		return new GenrePreference(
+			genrePreferenceEntity.getId(),
+			genrePreferenceEntity.getStoreId(),
+			genrePreferenceEntity.getGenreId()
+		);
+	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #68 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기존 엔티티들의 연관관계가 ManyToOne, OneToOne으로 설정되며 엔티티를 조회할 때 연결된 다른 엔티티까지 필수로 조회되는 n+1 쿼리 문제가 발생했었습니다.
이를 방지하고 도메인 분리의 취지에 맞도록 다른 엔티티와의 연관관계를 제거하고 연관된 엔티티의 id만 저장하도록 리팩토링했습니다.


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
이전 코드의 코드 포맷터 미적용으로 인해 코드 변화량이 많아보이지만 실질적인 변화는 많지 않습니다. 코드 수정 시 코드 포맷터 적용을 항상 생활화합시다 😁