### PR TITLE
[feat] #70 - 장르 관련 api 구현

### DIFF
--- a/src/main/java/com/napzak/domain/genre/api/controller/GenreController.java
+++ b/src/main/java/com/napzak/domain/genre/api/controller/GenreController.java
@@ -1,0 +1,94 @@
+package com.napzak.domain.genre.api.controller;
+
+import java.util.Objects;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.napzak.domain.genre.api.dto.response.GenreListResponse;
+import com.napzak.domain.genre.api.dto.response.GenreNameListResponse;
+import com.napzak.domain.genre.api.exception.GenreSuccessCode;
+import com.napzak.domain.genre.api.service.GenrePagination;
+import com.napzak.domain.genre.api.service.GenreService;
+import com.napzak.domain.genre.api.service.enums.SortOption;
+import com.napzak.global.auth.annotation.CurrentMember;
+import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.common.exception.code.ErrorCode;
+import com.napzak.global.common.exception.dto.SuccessResponse;
+import com.napzak.domain.genre.api.dto.request.cursor.OldestCursor;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+public class GenreController {
+	private final GenreService genreService;
+
+	@GetMapping("/onboarding/genres")
+	public ResponseEntity<SuccessResponse<GenreListResponse>> getGenres(
+		@RequestParam(required = false) String cursor,
+		@RequestParam(defaultValue = "39") int size
+	) {
+		SortOption sortOption = SortOption.OLDEST;
+
+		GenrePagination pagination = genreService.getGenres(
+			sortOption, parseCursorValues(cursor, sortOption), size);
+
+		GenreListResponse response = GenreListResponse.from(sortOption, pagination);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(GenreSuccessCode.GENRE_LIST_RETRIEVE_SUCCESS, response)
+		);
+	}
+
+	@GetMapping("/onboarding/genres/search")
+	public ResponseEntity<SuccessResponse<GenreListResponse>> searchGenres(
+		@RequestParam String searchWord,
+		@RequestParam(required = false) String cursor,
+		@RequestParam(defaultValue = "39") int size
+	) {
+		SortOption sortOption = SortOption.OLDEST;
+
+		GenrePagination pagination = genreService.searchGenres(
+			searchWord, sortOption, parseCursorValues(cursor, sortOption), size);
+
+		GenreListResponse response = GenreListResponse.from(sortOption, pagination);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(GenreSuccessCode.GENRE_LIST_RETRIEVE_SUCCESS, response)
+		);
+	}
+
+	@GetMapping("genres/search")
+	public ResponseEntity<SuccessResponse<GenreNameListResponse>> searchGenreNames(
+		@RequestParam String searchWord,
+		@RequestParam(required = false) String cursor,
+		@RequestParam(defaultValue = "39") int size,
+		@CurrentMember Long storeId
+	) {
+		SortOption sortOption = SortOption.OLDEST;
+
+		GenrePagination pagination = genreService.searchGenres(
+			searchWord, sortOption, parseCursorValues(cursor, sortOption), size);
+
+		GenreNameListResponse response = GenreNameListResponse.from(sortOption, pagination);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(GenreSuccessCode.GENRE_LIST_RETRIEVE_SUCCESS, response)
+		);
+	}
+
+	private Long parseCursorValues(String cursor, SortOption sortOption) {
+		if (cursor == null || cursor.isBlank()) {
+			return null;
+		}
+		if (Objects.requireNonNull(sortOption) == SortOption.OLDEST) {
+			return OldestCursor.fromString(cursor).getId();
+		}
+		throw new NapzakException(ErrorCode.INVALID_SORT_OPTION);
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/dto/request/cursor/OldestCursor.java
+++ b/src/main/java/com/napzak/domain/genre/api/dto/request/cursor/OldestCursor.java
@@ -1,0 +1,45 @@
+package com.napzak.domain.genre.api.dto.request.cursor;
+
+import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.common.exception.code.ErrorCode;
+
+public class OldestCursor {
+	private final Long id;
+
+	public OldestCursor(Long id) {
+		this.id = id;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	// O-{id}
+	@Override
+	public String toString() {
+		final StringBuilder stringBuilder = new StringBuilder();
+		return stringBuilder
+			.append("O-")
+			.append(id)
+			.toString();
+	}
+
+	public static OldestCursor fromString(String cursor) {
+		if (!cursor.startsWith("O-")) {
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
+		}
+		String[] split = cursor.split("-");
+
+		if (split.length != 2) {
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
+		}
+		final long id;
+
+		try{
+			id = Long.parseLong(split[1]);
+		} catch (NumberFormatException e) {
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
+		}
+		return new OldestCursor(id);
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/dto/response/GenreDto.java
+++ b/src/main/java/com/napzak/domain/genre/api/dto/response/GenreDto.java
@@ -1,0 +1,25 @@
+package com.napzak.domain.genre.api.dto.response;
+
+import com.napzak.domain.genre.core.vo.Genre;
+
+public record GenreDto(
+	Long genreId,
+	String genreName,
+	String genrePhoto
+) {
+	public static GenreDto from(Genre genre) {
+		return new GenreDto(
+			genre.getId(),
+			genre.getName(),
+			genre.getPhotoUrl()
+		);
+	}
+
+	public static GenreDto from(
+		Long genreId,
+		String genreName,
+		String genrePhoto
+	) {
+		return new GenreDto(genreId, genreName, genrePhoto);
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/dto/response/GenreListResponse.java
+++ b/src/main/java/com/napzak/domain/genre/api/dto/response/GenreListResponse.java
@@ -1,0 +1,36 @@
+package com.napzak.domain.genre.api.dto.response;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.napzak.domain.genre.api.service.GenrePagination;
+import com.napzak.domain.genre.api.service.enums.SortOption;
+
+public record GenreListResponse(
+	List<GenreDto> genreList,
+	@Nullable
+	String nextCursor
+) {
+	public static GenreListResponse from(
+		SortOption sortOption,
+		GenrePagination pagination
+	) {
+		List<GenreDto> genreDtos = pagination.getGenreList().stream()
+			.map(genre -> {
+				return GenreDto.from(genre);
+			}).toList();
+
+		String nextCursor = pagination.generateNextCursor(sortOption);
+
+		return new GenreListResponse(genreDtos, nextCursor);
+	}
+
+	public List<GenreDto> getGenreList() {
+		return genreList;
+	}
+
+	public String getNextCursor() {
+		return nextCursor;
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/dto/response/GenreNameDto.java
+++ b/src/main/java/com/napzak/domain/genre/api/dto/response/GenreNameDto.java
@@ -1,0 +1,22 @@
+package com.napzak.domain.genre.api.dto.response;
+
+import com.napzak.domain.genre.core.vo.Genre;
+
+public record GenreNameDto(
+	Long genreId,
+	String genreName
+) {
+	public static GenreNameDto from(Genre genre) {
+		return new GenreNameDto(
+			genre.getId(),
+			genre.getName()
+		);
+	}
+
+	public static GenreNameDto from(
+		Long genreId,
+		String genreName
+	) {
+		return new GenreNameDto(genreId, genreName);
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/dto/response/GenreNameListResponse.java
+++ b/src/main/java/com/napzak/domain/genre/api/dto/response/GenreNameListResponse.java
@@ -1,0 +1,36 @@
+package com.napzak.domain.genre.api.dto.response;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.napzak.domain.genre.api.service.GenrePagination;
+import com.napzak.domain.genre.api.service.enums.SortOption;
+
+public record GenreNameListResponse(
+	List<GenreNameDto> genreList,
+	@Nullable
+	String nextCursor
+) {
+	public static GenreNameListResponse from(
+		SortOption sortOption,
+		GenrePagination pagination
+	) {
+		List<GenreNameDto> genreNameDtos = pagination.getGenreList().stream()
+			.map(genre -> {
+				return GenreNameDto.from(genre);
+			}).toList();
+
+		String nextCursor = pagination.generateNextCursor(sortOption);
+
+		return new GenreNameListResponse(genreNameDtos, nextCursor);
+	}
+
+	public List<GenreNameDto> getGenreList() {
+		return genreList;
+	}
+
+	public String getNextCursor() {
+		return nextCursor;
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/exception/GenreErrorCode.java
+++ b/src/main/java/com/napzak/domain/genre/api/exception/GenreErrorCode.java
@@ -1,0 +1,21 @@
+package com.napzak.domain.genre.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.napzak.global.common.exception.base.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GenreErrorCode implements BaseErrorCode {
+	/*
+	404 Not Found
+	 */
+	GENRE_NOT_FOUND(HttpStatus.NOT_FOUND, "장르를 찾을 수 없습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/napzak/domain/genre/api/exception/GenreSuccessCode.java
+++ b/src/main/java/com/napzak/domain/genre/api/exception/GenreSuccessCode.java
@@ -1,0 +1,22 @@
+package com.napzak.domain.genre.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.napzak.global.common.exception.base.BaseSuccessCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GenreSuccessCode implements BaseSuccessCode {
+	/*
+	200 Ok
+	 */
+	GENRE_LIST_RETRIEVE_SUCCESS(HttpStatus.OK, "장르 목록이 조회되었습니다."),
+	GENRE_LIST_SEARCH_SUCCESS(HttpStatus.OK, "검색된 장르 목록이 조회되었습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/napzak/domain/genre/api/service/GenrePagination.java
+++ b/src/main/java/com/napzak/domain/genre/api/service/GenrePagination.java
@@ -1,0 +1,48 @@
+package com.napzak.domain.genre.api.service;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.napzak.domain.genre.api.dto.request.cursor.OldestCursor;
+import com.napzak.domain.genre.api.exception.GenreErrorCode;
+import com.napzak.domain.genre.core.vo.Genre;
+import com.napzak.domain.genre.core.vo.GenreList;
+import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.common.exception.code.ErrorCode;
+import com.napzak.domain.genre.api.service.enums.SortOption;
+
+public class GenrePagination {
+	private final int needSize;
+	private final GenreList genreList;
+
+	public GenrePagination(int needSize, GenreList genreList) {
+		this.needSize = needSize;
+		if (genreList == null || genreList.isEmpty()) {
+			throw new NapzakException(GenreErrorCode.GENRE_NOT_FOUND);
+		}
+		this.genreList = genreList;
+	}
+
+	private boolean hasMoreData() {
+		return genreList.size() > needSize;
+	}
+
+	@Nullable
+	public String generateNextCursor(SortOption sortOption) {
+		if (!hasMoreData()) {
+			return null;
+		}
+		Genre lastGenre = genreList.getGenreList().get(needSize);
+		switch (sortOption) {
+			case OLDEST:
+				return new OldestCursor(lastGenre.getId()).toString();
+			default:
+				throw new NapzakException(ErrorCode.INVALID_SORT_OPTION);
+		}
+	}
+
+	public List<Genre> getGenreList() {
+		return genreList.getGenreList().subList(0, Math.min(needSize, genreList.size()));
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/service/GenreService.java
+++ b/src/main/java/com/napzak/domain/genre/api/service/GenreService.java
@@ -1,0 +1,30 @@
+package com.napzak.domain.genre.api.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.napzak.domain.genre.core.GenreRetriever;
+import com.napzak.domain.genre.core.vo.Genre;
+import com.napzak.domain.genre.core.vo.GenreList;
+import com.napzak.domain.genre.api.service.enums.SortOption;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GenreService {
+	private final GenreRetriever genreRetriever;
+
+	public GenrePagination getGenres(SortOption sortOption, Long cursorGenreId, int size) {
+		List<Genre> genres = genreRetriever.retrieveGenres(sortOption, cursorGenreId, size);
+
+		return new GenrePagination(size, new GenreList(genres));
+	}
+
+	public GenrePagination searchGenres(String searchWord, SortOption sortOption, Long cursorGenreId, int size) {
+		List<Genre> genres = genreRetriever.searchGenres(searchWord, sortOption, cursorGenreId, size);
+
+		return new GenrePagination(size, new GenreList(genres));
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/service/enums/SortOption.java
+++ b/src/main/java/com/napzak/domain/genre/api/service/enums/SortOption.java
@@ -1,0 +1,34 @@
+package com.napzak.domain.genre.api.service.enums;
+
+import com.napzak.domain.product.core.entity.ProductEntity;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+
+public enum SortOption {
+	OLDEST("id", com.querydsl.core.types.Order.ASC),
+	;
+
+	private final String fieldName;
+	private final com.querydsl.core.types.Order order;
+
+	SortOption(String fieldName, com.querydsl.core.types.Order order) {
+		this.fieldName = fieldName;
+		this.order = order;
+	}
+
+	public String getFieldName() {
+		return fieldName;
+	}
+
+	public com.querydsl.core.types.Order getOrder() {
+		return order;
+	}
+
+	public OrderSpecifier<?> toOrderSpecifier() {
+		PathBuilder<ProductEntity> entityPath = new PathBuilder<>(ProductEntity.class, "genreEntity");
+		Expression<? extends Comparable> path = entityPath.get(fieldName, Comparable.class);
+
+		return new OrderSpecifier<>(order, path);
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/core/GenreRepository.java
+++ b/src/main/java/com/napzak/domain/genre/core/GenreRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import com.napzak.domain.genre.core.entity.GenreEntity;
 
 @Repository
-public interface GenreRepository extends JpaRepository<GenreEntity, Long> {
+public interface GenreRepository extends JpaRepository<GenreEntity, Long>, GenreRepositoryCustom {
 	@Query("SELECT g.name FROM GenreEntity g WHERE g.id = :id")
 	String findNameById(@Param("id") Long id);
 

--- a/src/main/java/com/napzak/domain/genre/core/GenreRepositoryCustom.java
+++ b/src/main/java/com/napzak/domain/genre/core/GenreRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.napzak.domain.genre.core;
+
+import java.util.List;
+
+import com.napzak.domain.genre.core.entity.GenreEntity;
+import com.querydsl.core.types.OrderSpecifier;
+
+public interface GenreRepositoryCustom {
+	List<GenreEntity> getGenresByWithCursor(
+		OrderSpecifier<?> orderSpecifier, Long cursorGenreId, int size);
+
+	List<GenreEntity> searchGenresBySearchWordWithCursor(
+		String searchWord, OrderSpecifier<?> orderSpecifier, Long cursorGenreId, int size);
+}

--- a/src/main/java/com/napzak/domain/genre/core/GenreRepositoryCustomImpl.java
+++ b/src/main/java/com/napzak/domain/genre/core/GenreRepositoryCustomImpl.java
@@ -1,0 +1,84 @@
+package com.napzak.domain.genre.core;
+
+import static com.napzak.domain.genre.core.entity.QGenreEntity.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.napzak.domain.genre.core.entity.GenreEntity;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class GenreRepositoryCustomImpl implements GenreRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<GenreEntity> getGenresByWithCursor(
+		OrderSpecifier<?> orderSpecifier, Long cursorGenreId, int size) {
+		return queryFactory.selectFrom(genreEntity)
+			.where(cursorFilter(cursorGenreId, orderSpecifier))
+			.orderBy(orderSpecifier)
+			.limit(size + 1)
+			.fetch();
+	}
+
+	@Override
+	public List<GenreEntity> searchGenresBySearchWordWithCursor(
+		String searchWord, OrderSpecifier<?> orderSpecifier, Long cursorGenreId, int size) {
+		return queryFactory.selectFrom(genreEntity)
+			.where(
+				matchGenreName(searchWord).gt(0),
+				cursorFilter(cursorGenreId, orderSpecifier)
+			)
+			.orderBy(orderSpecifier)
+			.limit(size + 1)
+			.fetch();
+	}
+
+	private BooleanExpression cursorFilter(Long cursorGenreId, OrderSpecifier<?> orderSpecifier) {
+		if (cursorGenreId == null) {
+			return null;
+		}
+
+		String fieldName = ((PathBuilder<?>) orderSpecifier.getTarget()).getMetadata().getName();
+		com.querydsl.core.types.Order direction = orderSpecifier.getOrder();
+
+		if (fieldName.equals("id")) {
+			return direction == com.querydsl.core.types.Order.ASC
+				? genreEntity.id.goe(cursorGenreId)
+				: genreEntity.id.loe(cursorGenreId);
+		}
+
+		return null;
+	}
+
+	private NumberTemplate<Double> matchGenreName(String searchWord) {
+		if (searchWord == null || searchWord.isBlank()) {
+			return Expressions.numberTemplate(Double.class, "0");
+		}
+
+		String[] tokens = searchWord.trim().split("\\s+");
+		String booleanQuery = "+" + String.join(" +", tokens);
+
+		log.info("Generated Boolean Query for searchWord '{}': {}", searchWord, booleanQuery);
+
+		return Expressions.numberTemplate(
+			Double.class,
+			"function('match', {0}, {1})",
+			genreEntity.name,
+			booleanQuery
+		);
+	}
+
+}

--- a/src/main/java/com/napzak/domain/genre/core/GenreRetriever.java
+++ b/src/main/java/com/napzak/domain/genre/core/GenreRetriever.java
@@ -7,6 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.napzak.domain.genre.core.vo.Genre;
+import com.napzak.domain.genre.api.service.enums.SortOption;
+
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -15,16 +18,36 @@ public class GenreRetriever {
 	private final GenreRepository genreRepository;
 
 	@Transactional(readOnly = true)
-	public String getGenreNameById(Long genreId) {
+	public String retrieveGenreNameById(Long genreId) {
 		return genreRepository.findNameById(genreId);
 	}
 
 	@Transactional(readOnly = true)
-	public Map<Long, String> getGenreNamesByIds(List<Long> genreIds) {
+	public Map<Long, String> retrieveGenreNamesByIds(List<Long> genreIds) {
 		return genreRepository.findNamesByIds(genreIds).stream()
 			.collect(Collectors.toMap(
 				result -> (Long)result[0],   // Key: Genre ID
 				result -> (String)result[1] // Value: Genre Name
 			));
+	}
+
+	@Transactional(readOnly = true)
+	public List<Genre> retrieveGenres(SortOption sortOption, Long cursorGenreId, int size) {
+
+		return genreRepository.getGenresByWithCursor(
+				sortOption.toOrderSpecifier(), cursorGenreId, size
+			).stream()
+			.map(Genre::fromEntity)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<Genre> searchGenres(String searchWord, SortOption sortOption, Long cursorGenreId, int size) {
+
+		return genreRepository.searchGenresBySearchWordWithCursor(
+				searchWord, sortOption.toOrderSpecifier(), cursorGenreId, size
+			).stream()
+			.map(Genre::fromEntity)
+			.toList();
 	}
 }

--- a/src/main/java/com/napzak/domain/genre/core/vo/GenreList.java
+++ b/src/main/java/com/napzak/domain/genre/core/vo/GenreList.java
@@ -1,0 +1,44 @@
+package com.napzak.domain.genre.core.vo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+public class GenreList {
+	private final List<Genre> genreList;
+
+	public GenreList(List<Genre> genreList) {
+		this.genreList = Objects.requireNonNullElseGet(genreList, ArrayList::new);
+	}
+
+	@Nullable
+	public Genre first() {
+		return genreList.stream()
+			.findFirst()
+			.orElseGet(() -> null);
+	}
+
+	@Nullable
+	public Genre last() {
+		if (genreList.isEmpty()) {
+			return null;
+		}
+
+		final int lastIndex = genreList.size() - 1;
+		return genreList.get(lastIndex);
+	}
+
+	public int size() {
+		return genreList.size();
+	}
+
+	public boolean isEmpty() {
+		return genreList.isEmpty();
+	}
+
+	public List<Genre> getGenreList() {
+		return genreList;
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/ProductGenreFacade.java
+++ b/src/main/java/com/napzak/domain/product/api/ProductGenreFacade.java
@@ -15,10 +15,10 @@ public class ProductGenreFacade {
 	private final GenreRetriever genreRetriever;
 
 	public String getGenreName(Long genreId) {
-		return genreRetriever.getGenreNameById(genreId);
+		return genreRetriever.retrieveGenreNameById(genreId);
 	}
 
 	public Map<Long, String> getGenreNames(List<Long> genreIds) {
-		return genreRetriever.getGenreNamesByIds(genreIds);
+		return genreRetriever.retrieveGenreNamesByIds(genreIds);
 	}
 }

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -10,13 +10,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.napzak.global.common.exception.code.ErrorCode;
 import com.napzak.domain.product.api.dto.request.cursor.HighPriceCursor;
 import com.napzak.domain.product.api.dto.request.cursor.LowPriceCursor;
 import com.napzak.domain.product.api.dto.request.cursor.PopularCursor;
 import com.napzak.domain.product.api.dto.request.cursor.RecentCursor;
 import com.napzak.domain.product.api.dto.response.ProductBuyListResponse;
 import com.napzak.domain.product.api.dto.response.ProductSellListResponse;
-import com.napzak.domain.product.api.exception.ProductErrorCode;
 import com.napzak.domain.product.api.exception.ProductSuccessCode;
 import com.napzak.domain.product.api.service.ProductPagination;
 import com.napzak.domain.product.api.service.ProductService;
@@ -293,7 +293,7 @@ public class ProductController {
 		try {
 			return SortOption.valueOf(sortOption.toUpperCase());
 		} catch (IllegalArgumentException e) {
-			throw new NapzakException(ProductErrorCode.INVALID_SORT_OPTION);
+			throw new NapzakException(ErrorCode.INVALID_SORT_OPTION);
 		}
 	}
 
@@ -320,10 +320,10 @@ public class ProductController {
 					HighPriceCursor priceCursor = HighPriceCursor.fromString(cursor);
 					return new CursorValues(priceCursor.getId(), priceCursor.getPrice());
 				}
-				default -> throw new NapzakException(ProductErrorCode.INVALID_SORT_OPTION);
+				default -> throw new NapzakException(ErrorCode.INVALID_SORT_OPTION);
 			}
 		} catch (IllegalArgumentException e) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 	}
 

--- a/src/main/java/com/napzak/domain/product/api/dto/request/cursor/Cursor.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/cursor/Cursor.java
@@ -1,6 +1,6 @@
 package com.napzak.domain.product.api.dto.request.cursor;
 
-import com.napzak.domain.product.api.exception.ProductErrorCode;
+import com.napzak.global.common.exception.code.ErrorCode;
 import com.napzak.domain.product.api.service.enums.SortOption;
 import com.napzak.global.common.exception.NapzakException;
 
@@ -18,7 +18,7 @@ public abstract class Cursor {
 			case HIGH_PRICE:
 				return HighPriceCursor.fromString(cursor);
 			default:
-				throw new NapzakException(ProductErrorCode.INVALID_SORT_OPTION);
+				throw new NapzakException(ErrorCode.INVALID_SORT_OPTION);
 		}
 	}
 }

--- a/src/main/java/com/napzak/domain/product/api/dto/request/cursor/HighPriceCursor.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/cursor/HighPriceCursor.java
@@ -1,13 +1,13 @@
 package com.napzak.domain.product.api.dto.request.cursor;
 
-import com.napzak.domain.product.api.exception.ProductErrorCode;
 import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.common.exception.code.ErrorCode;
 
-public class HighPriceCursor extends Cursor{
+public class HighPriceCursor extends Cursor {
 	private final int price;
 	private final long id;
 
-	public HighPriceCursor(int price, long id){
+	public HighPriceCursor(int price, long id) {
 		this.price = price;
 		this.id = id;
 	}
@@ -33,24 +33,24 @@ public class HighPriceCursor extends Cursor{
 			.toString();
 	}
 
-	public static HighPriceCursor fromString(String cursor){
+	public static HighPriceCursor fromString(String cursor) {
 		if (!cursor.startsWith("H-")) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		String[] split = cursor.split("-");
 
 		if (split.length != 3) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 
 		final long id;
 		final int price;
 
-		try{
+		try {
 			price = Integer.parseInt(split[1]);
 			id = Long.parseLong(split[2]);
 		} catch (NumberFormatException e) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		return new HighPriceCursor(price, id);
 	}

--- a/src/main/java/com/napzak/domain/product/api/dto/request/cursor/LowPriceCursor.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/cursor/LowPriceCursor.java
@@ -1,13 +1,13 @@
 package com.napzak.domain.product.api.dto.request.cursor;
 
-import com.napzak.domain.product.api.exception.ProductErrorCode;
 import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.common.exception.code.ErrorCode;
 
 public class LowPriceCursor extends Cursor {
 	private final int price;
 	private final long id;
 
-	public LowPriceCursor(int price, long id){
+	public LowPriceCursor(int price, long id) {
 		this.price = price;
 		this.id = id;
 	}
@@ -33,24 +33,24 @@ public class LowPriceCursor extends Cursor {
 			.toString();
 	}
 
-	public static LowPriceCursor fromString(String cursor){
+	public static LowPriceCursor fromString(String cursor) {
 		if (!cursor.startsWith("L-")) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		String[] split = cursor.split("-");
 
 		if (split.length != 3) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 
 		final long id;
 		final int price;
 
-		try{
+		try {
 			price = Integer.parseInt(split[1]);
 			id = Long.parseLong(split[2]);
 		} catch (NumberFormatException e) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		return new LowPriceCursor(price, id);
 	}

--- a/src/main/java/com/napzak/domain/product/api/dto/request/cursor/PopularCursor.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/cursor/PopularCursor.java
@@ -1,7 +1,7 @@
 package com.napzak.domain.product.api.dto.request.cursor;
 
-import com.napzak.domain.product.api.exception.ProductErrorCode;
 import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.common.exception.code.ErrorCode;
 
 public class PopularCursor extends Cursor {
 	private final int interestCount;
@@ -33,24 +33,24 @@ public class PopularCursor extends Cursor {
 			.toString();
 	}
 
-	public static PopularCursor fromString(String cursor){
+	public static PopularCursor fromString(String cursor) {
 		if (!cursor.startsWith("P-")) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		String[] split = cursor.split("-");
 
 		if (split.length != 3) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 
 		final int interestCount;
 		final long id;
 
-		try{
+		try {
 			interestCount = Integer.parseInt(split[1]);
 			id = Long.parseLong(split[2]);
 		} catch (NumberFormatException e) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		return new PopularCursor(interestCount, id);
 	}

--- a/src/main/java/com/napzak/domain/product/api/dto/request/cursor/RecentCursor.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/cursor/RecentCursor.java
@@ -1,7 +1,7 @@
 package com.napzak.domain.product.api.dto.request.cursor;
 
-import com.napzak.domain.product.api.exception.ProductErrorCode;
 import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.common.exception.code.ErrorCode;
 
 public class RecentCursor extends Cursor {
 	private final Long id;
@@ -26,19 +26,19 @@ public class RecentCursor extends Cursor {
 
 	public static RecentCursor fromString(String cursor) {
 		if (!cursor.startsWith("R-")) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		String[] split = cursor.split("-");
 
 		if (split.length != 2) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		final long id;
 
-		try{
+		try {
 			id = Long.parseLong(split[1]);
 		} catch (NumberFormatException e) {
-			throw new NapzakException(ProductErrorCode.INVALID_CURSOR_FORMAT);
+			throw new NapzakException(ErrorCode.INVALID_CURSOR_FORMAT);
 		}
 		return new RecentCursor(id);
 	}

--- a/src/main/java/com/napzak/domain/product/api/exception/ProductErrorCode.java
+++ b/src/main/java/com/napzak/domain/product/api/exception/ProductErrorCode.java
@@ -11,12 +11,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProductErrorCode implements BaseErrorCode {
 	/*
-	400 Bad Request
-	 */
-	INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 커서입니다."),
-	INVALID_SORT_OPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 정렬기준입니다."),
-
-	/*
 	404 Not Found
 	 */
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),

--- a/src/main/java/com/napzak/domain/product/api/service/ProductPagination.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductPagination.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import com.napzak.global.common.exception.code.ErrorCode;
 import com.napzak.domain.product.api.dto.request.cursor.HighPriceCursor;
 import com.napzak.domain.product.api.dto.request.cursor.LowPriceCursor;
 import com.napzak.domain.product.api.dto.request.cursor.PopularCursor;
@@ -48,7 +49,7 @@ public class ProductPagination {
 			case HIGH_PRICE:
 				return new HighPriceCursor(lastProduct.getPrice(), lastProduct.getId()).toString();
 			default:
-				throw new NapzakException(ProductErrorCode.INVALID_SORT_OPTION);
+				throw new NapzakException(ErrorCode.INVALID_SORT_OPTION);
 		}
 	}
 

--- a/src/main/java/com/napzak/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/napzak/global/common/config/SecurityConfig.java
@@ -31,9 +31,10 @@ public class SecurityConfig {
 		"/v3/api-docs/**",
 		"/swagger-ui/**",
 		"/swagger-resources/**",
-		"/api/files/**",
+		"/api/v1/files/**",
 		"/error",
-		"/api/stores/login/**",
+		"/api/v1/stores/login/**",
+		"/api/v1/onboarding/**",
 		"/"
 	};
 

--- a/src/main/java/com/napzak/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/napzak/global/common/exception/code/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode implements BaseErrorCode {
 	INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 본문이 올바르지 않습니다."),
 	DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "데이터 무결성 제약 조건을 위반했습니다."),
 	BUSINESS_LOGIC_ERROR(HttpStatus.BAD_REQUEST, "비즈니스 로직 처리 중 오류가 발생했습니다."),
+	INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 커서입니다."),
+	INVALID_SORT_OPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 정렬기준입니다."),
 
 	/*
 	 404 NOT FOUND


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #70 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 선호장르 목록 조회 api 구현
- 선호장르 검색 api 구현
- 장르명 검색 api 구현

커서 페이지네이션 적용했으며 상품 목록 조회 및 검색과 비슷한 방식으로 구현했습니다!

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 선호장르 목록 조회 api
<img width="768" alt="image" src="https://github.com/user-attachments/assets/d081bd79-23d6-4a5a-81e0-9ed132c97ea9" />
<img width="777" alt="image" src="https://github.com/user-attachments/assets/c46ce5c3-4afb-4505-a23b-bce036240750" />
페이징 적용 및 커서 작동까지 확인했습니다.

### 선호장르 검색 api
<img width="778" alt="image" src="https://github.com/user-attachments/assets/3db2e15a-0762-4117-a2ad-adb5a0508c32" />
한글자도 잘 검색됩니다.
<img width="784" alt="image" src="https://github.com/user-attachments/assets/f032a12c-6ec8-499a-bfcf-4440a3f89d65" />
<img width="759" alt="image" src="https://github.com/user-attachments/assets/0fe5449b-4df1-4817-861c-2b645d309e71" />
공백 포함 검색어 처리도 확인했습니다.

### 장르명 검색 api
<img width="776" alt="image" src="https://github.com/user-attachments/assets/7dcffffa-f73b-4a59-98eb-6015c4f47309" />

<img width="773" alt="image" src="https://github.com/user-attachments/assets/a024baec-78e9-4b80-98b6-256f94f1214a" />
마찬가지로 검색 잘 되는 것 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
cursor, sortOption 관련 errorCode가 product, genre 도메인에서 둘 다 쓰여서 global의 errorCode로 빼봤는데 각 도메인에 적는게 좋을지 global에 두는 게 좋을지 의견이 궁금합니다!