### PR TITLE
[feat] #72 - 상품 등록 관련 api 구현

### DIFF
--- a/src/main/java/com/napzak/domain/interest/core/entity/InterestEntity.java
+++ b/src/main/java/com/napzak/domain/interest/core/entity/InterestEntity.java
@@ -27,10 +27,8 @@ public class InterestEntity {
 
 	@Builder
 	public InterestEntity(
-		Long id,
 		Long productId,
 		Long storeId) {
-		this.id = id;
 		this.productId = productId;
 		this.storeId = storeId;
 	}

--- a/src/main/java/com/napzak/domain/product/api/annotation/SequenceValidator.java
+++ b/src/main/java/com/napzak/domain/product/api/annotation/SequenceValidator.java
@@ -1,0 +1,36 @@
+package com.napzak.domain.product.api.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import com.napzak.domain.product.api.dto.request.ProductPhotoRequestDto;
+
+public class SequenceValidator implements ConstraintValidator<ValidSequence, List<ProductPhotoRequestDto>> {
+
+	@Override
+	public boolean isValid(List<ProductPhotoRequestDto> productPhotoList, ConstraintValidatorContext context) {
+		if (productPhotoList == null || productPhotoList.isEmpty()) {
+			return false; // 빈 리스트는 유효하지 않음
+		}
+
+		List<Integer> sequenceList = productPhotoList.stream()
+			.map(ProductPhotoRequestDto::sequence)
+			.toList();
+
+		// 중복 체크
+		if (new HashSet<>(sequenceList).size() != sequenceList.size()) {
+			return false;
+		}
+
+		// 1부터 리스트 크기까지 연속성 체크
+		int maxSequence = productPhotoList.size();
+		List<Integer> expectedSequence = IntStream.rangeClosed(1, maxSequence)
+			.boxed()
+			.toList();
+
+		return new HashSet<>(sequenceList).containsAll(expectedSequence);
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/annotation/ValidSequence.java
+++ b/src/main/java/com/napzak/domain/product/api/annotation/ValidSequence.java
@@ -1,0 +1,15 @@
+package com.napzak.domain.product.api.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = SequenceValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidSequence {
+	String message() default "사진 순서는 중복될 수 없으며 1부터 순차적으로 구성되어야 합니다.";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -298,7 +298,7 @@ public class ProductController {
 			productSellCreateRequest.isDeliveryIncluded(),
 			productSellCreateRequest.standardDeliveryFee(),
 			productSellCreateRequest.halfDeliveryFee(),
-			productSellCreateRequest.condition(),
+			productSellCreateRequest.productCondition(),
 			productSellCreateRequest.genreId()
 		);
 

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductBuyCreateRequest.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductBuyCreateRequest.java
@@ -1,0 +1,37 @@
+package com.napzak.domain.product.api.dto.request;
+
+import java.util.List;
+
+import com.napzak.domain.product.api.annotation.ValidSequence;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record ProductBuyCreateRequest(
+	@NotNull
+	@Size(min = 1, max =10, message = "사진은 최소 1개 이상, 최대 10개까지 등록할 수 있습니다.")
+	@Valid
+	@ValidSequence
+	List<ProductPhotoRequestDto> productPhotoList,
+
+	@NotNull
+	long genreId,
+
+	@NotBlank
+	@Size(max = 48, message = "상품 제목은 자를 초과할 수 없습니다.")
+	String title,
+
+	@NotBlank
+	@Size(max = 500, message = "상품 설명은 자를 초과할 수 없습니다.")
+	String description,
+
+	@NotNull
+	@Positive(message = "가격은 0보다 커야합니다.")
+	int price,
+
+	boolean isPriceNegotiable
+) {
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductBuyCreateRequest.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductBuyCreateRequest.java
@@ -21,11 +21,11 @@ public record ProductBuyCreateRequest(
 	long genreId,
 
 	@NotBlank
-	@Size(max = 48, message = "상품 제목은 자를 초과할 수 없습니다.")
+	@Size(max = 50, message = "상품 제목은 50자를 초과할 수 없습니다.")
 	String title,
 
 	@NotBlank
-	@Size(max = 500, message = "상품 설명은 자를 초과할 수 없습니다.")
+	@Size(max = 250, message = "상품 설명은 250자를 초과할 수 없습니다.")
 	String description,
 
 	@NotNull

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductPhotoRequestDto.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductPhotoRequestDto.java
@@ -1,0 +1,13 @@
+package com.napzak.domain.product.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record ProductPhotoRequestDto(
+	@NotBlank(message = "사진 URL은 비어 있을 수 없습니다.")
+	String photoUrl,
+
+	@Positive(message = "사진 순서는 1 이상이어야 합니다.")
+	int sequence
+) {
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductSellCreateRequest.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductSellCreateRequest.java
@@ -33,7 +33,7 @@ public record ProductSellCreateRequest(
 
 	@NotNull
 	@ValidEnum(enumClass = ProductCondition.class, message = "유효하지 않은 상품 상태입니다.")
-	ProductCondition condition,
+	ProductCondition productCondition,
 
 	@NotNull
 	@Positive(message = "가격은 0보다 커야합니다.")

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductSellCreateRequest.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductSellCreateRequest.java
@@ -24,11 +24,11 @@ public record ProductSellCreateRequest(
 	long genreId,
 
 	@NotBlank(message = "상품 제목을 입력해 주세요.")
-	@Size(max = 48, message = "상품 제목은 자를 초과할 수 없습니다.")
+	@Size(max = 50, message = "상품 제목은 50자를 초과할 수 없습니다.")
 	String title,
 
 	@NotBlank(message = "상품 설명을 입력해 주세요.")
-	@Size(max = 500, message = "상품 설명은 자를 초과할 수 없습니다.")
+	@Size(max = 250, message = "상품 설명은 250자를 초과할 수 없습니다.")
 	String description,
 
 	@NotNull
@@ -46,7 +46,7 @@ public record ProductSellCreateRequest(
 	int standardDeliveryFee,
 
 	@NotNull
-	@PositiveOrZero(message = "반값배송비는 0보다 이상이어야 합니다.")
+	@PositiveOrZero(message = "반값배송비는 0 이상이어야 합니다.")
 	int halfDeliveryFee
 ) {
 }

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductSellCreateRequest.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductSellCreateRequest.java
@@ -1,0 +1,52 @@
+package com.napzak.domain.product.api.dto.request;
+
+import java.util.List;
+
+import com.napzak.domain.product.api.annotation.ValidSequence;
+import com.napzak.domain.product.core.entity.enums.ProductCondition;
+import com.napzak.global.common.annotation.ValidEnum;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+public record ProductSellCreateRequest(
+	@NotNull
+	@Size(min = 1, max =10, message = "사진은 최소 1개 이상, 최대 10개까지 등록할 수 있습니다.")
+	@Valid
+	@ValidSequence
+	List<ProductPhotoRequestDto> productPhotoList,
+
+	@NotNull
+	long genreId,
+
+	@NotBlank(message = "상품 제목을 입력해 주세요.")
+	@Size(max = 48, message = "상품 제목은 자를 초과할 수 없습니다.")
+	String title,
+
+	@NotBlank(message = "상품 설명을 입력해 주세요.")
+	@Size(max = 500, message = "상품 설명은 자를 초과할 수 없습니다.")
+	String description,
+
+	@NotNull
+	@ValidEnum(enumClass = ProductCondition.class, message = "유효하지 않은 상품 상태입니다.")
+	ProductCondition condition,
+
+	@NotNull
+	@Positive(message = "가격은 0보다 커야합니다.")
+	int price,
+
+	boolean isDeliveryIncluded,
+
+	@NotNull
+	@PositiveOrZero(message = "일반배송비는 0 이상이어야 합니다.")
+	int standardDeliveryFee,
+
+	@NotNull
+	@PositiveOrZero(message = "반값배송비는 0보다 이상이어야 합니다.")
+	int halfDeliveryFee
+) {
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyResponse.java
@@ -1,0 +1,34 @@
+package com.napzak.domain.product.api.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.napzak.domain.product.core.vo.Product;
+import com.napzak.domain.product.core.vo.ProductPhoto;
+
+public record ProductBuyResponse(
+	long productId,
+	List<ProductPhotoResponseDto> productPhotoList,
+	long genreId,
+	String title,
+	String description,
+	int price,
+	boolean isPriceNegotiable,
+	LocalDateTime createdAt
+) {
+	public static ProductBuyResponse from(Product product, List<ProductPhoto> photos) {
+		List<ProductPhotoResponseDto> productPhotoResponseDtos = photos.stream()
+			.map(ProductPhotoResponseDto::from).toList();
+
+		return new ProductBuyResponse(
+			product.getId(),
+			productPhotoResponseDtos,
+			product.getGenreId(),
+			product.getTitle(),
+			product.getDescription(),
+			product.getPrice(),
+			product.getIsPriceNegotiable(),
+			product.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductPhotoResponseDto.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductPhotoResponseDto.java
@@ -1,0 +1,15 @@
+package com.napzak.domain.product.api.dto.response;
+
+import com.napzak.domain.product.core.vo.ProductPhoto;
+
+public record ProductPhotoResponseDto(
+	long photoId,
+	String photoUrl,
+	int sequence
+) {
+	public static ProductPhotoResponseDto from(ProductPhoto photo) {
+		return new ProductPhotoResponseDto(photo.getId(),
+			photo.getPhotoUrl(),
+			photo.getSequence());
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellResponse.java
@@ -1,0 +1,41 @@
+package com.napzak.domain.product.api.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.napzak.domain.product.core.entity.enums.ProductCondition;
+import com.napzak.domain.product.core.vo.Product;
+import com.napzak.domain.product.core.vo.ProductPhoto;
+
+public record ProductSellResponse(
+	long productId,
+	List<ProductPhotoResponseDto> productPhotoList,
+	long genreId,
+	String title,
+	String description,
+	ProductCondition productCondition,
+	int price,
+	boolean isDeliveryIncluded,
+	int standardDeliveryFee,
+	int halfDeliveryFee,
+	LocalDateTime createdAt
+) {
+	public static ProductSellResponse from(Product product, List<ProductPhoto> photos) {
+		List<ProductPhotoResponseDto> productPhotoResponseDtos = photos.stream()
+			.map(ProductPhotoResponseDto::from).toList();
+
+		return new ProductSellResponse(
+			product.getId(),
+			productPhotoResponseDtos,
+			product.getGenreId(),
+			product.getTitle(),
+			product.getDescription(),
+			product.getProductCondition(),
+			product.getPrice(),
+			product.getIsDeliveryIncluded(),
+			product.getStandardDeliveryFee(),
+			product.getHalfDeliveryFee(),
+			product.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/exception/ProductErrorCode.java
+++ b/src/main/java/com/napzak/domain/product/api/exception/ProductErrorCode.java
@@ -11,6 +11,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProductErrorCode implements BaseErrorCode {
 	/*
+	400 Bad Request
+	 */
+	PRODUCT_PHOTO_SEQUENCE_DUPLICATED(HttpStatus.BAD_REQUEST, "사진 순서는 중복될 수 없습니다."),
+
+	/*
 	404 Not Found
 	 */
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),

--- a/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
+++ b/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
@@ -19,6 +19,11 @@ public enum ProductSuccessCode implements BaseSuccessCode {
 	RECOMMEND_PRODUCT_GET_SUCCESS(HttpStatus.OK, "개인화 상품 불러오기 성공"),
 	TOP_SELL_PRODUCT_GET_SUCCESS(HttpStatus.OK, "팔아요 인기 상품 불러오기 성공"),
 	TOP_BUY_PRODUCT_GET_SUCCESS(HttpStatus.OK, "구해요 인기 상품 불러오기 성공"),
+
+	/*
+	201 Created
+	 */
+	PRODUCT_CREATE_SUCCESS(HttpStatus.OK, "상품이 등록되었습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
+++ b/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
@@ -23,7 +23,7 @@ public enum ProductSuccessCode implements BaseSuccessCode {
 	/*
 	201 Created
 	 */
-	PRODUCT_CREATE_SUCCESS(HttpStatus.OK, "상품이 등록되었습니다."),
+	PRODUCT_CREATE_SUCCESS(HttpStatus.CREATED, "상품이 등록되었습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/napzak/domain/product/api/service/ProductService.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductService.java
@@ -4,12 +4,18 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.domain.product.api.service.enums.SortOption;
 import com.napzak.domain.product.core.ProductPhotoRetriever;
+import com.napzak.domain.product.core.ProductPhotoSaver;
 import com.napzak.domain.product.core.ProductRetriever;
+import com.napzak.domain.product.core.ProductSaver;
+import com.napzak.domain.product.core.entity.enums.ProductCondition;
+import com.napzak.domain.product.core.entity.enums.TradeStatus;
 import com.napzak.domain.product.core.entity.enums.TradeType;
 import com.napzak.domain.product.core.vo.Product;
+import com.napzak.domain.product.core.vo.ProductPhoto;
 import com.napzak.domain.product.core.vo.ProductWithFirstPhoto;
 import com.napzak.domain.product.core.vo.ProductWithFirstPhotoList;
 
@@ -20,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 public class ProductService {
 	private final ProductRetriever productRetriever;
 	private final ProductPhotoRetriever productPhotoRetriever;
+	private final ProductSaver productSaver;
+	private final ProductPhotoSaver productPhotoSaver;
 
 	public ProductPagination getSellProducts(
 		SortOption sortOption, Long cursorProductId, Integer cursorOptionalValue, int size,
@@ -97,6 +105,41 @@ public class ProductService {
 			),
 			size
 		);
+	}
+
+	@Transactional
+	public Product createSellProduct(
+		String title, Long storeId, String description,
+		int price, Boolean isDeliveryIncluded, int standardDeliveryFee, int halfDeliveryFee,
+		ProductCondition productCondition, Long genreId
+	) {
+		Product product = productSaver.save(
+			title, storeId, description, TradeType.SELL, TradeStatus.BEFORE_TRADE, price,
+			false, isDeliveryIncluded, standardDeliveryFee,
+			halfDeliveryFee, productCondition, genreId
+		);
+
+		return product;
+	}
+
+	@Transactional
+	public Product createBuyProduct(
+		String title, Long storeId, String description,
+		int price, Boolean isPriceNegotiable, Long genreId
+	) {
+		Product product = productSaver.save(
+			title, storeId, description, TradeType.BUY, TradeStatus.BEFORE_TRADE, price,
+			isPriceNegotiable, false, 0,
+			0, null, genreId
+		);
+
+		return product;
+	}
+
+	@Transactional
+	public List<ProductPhoto> createProductPhotos(Long productId, Map<Integer, String> photoData) {
+
+		return productPhotoSaver.saveAll(productId, photoData);
 	}
 
 	private ProductPagination retrieveAndPreparePagination(

--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoSaver.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoSaver.java
@@ -1,0 +1,32 @@
+package com.napzak.domain.product.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.napzak.domain.product.core.entity.ProductPhotoEntity;
+import com.napzak.domain.product.core.vo.ProductPhoto;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductPhotoSaver {
+	private final ProductPhotoRepository productPhotoRepository;
+
+	@Transactional
+	public List<ProductPhoto> saveAll(final Long productId, final Map<Integer, String> photoData) {
+		List<ProductPhotoEntity> productPhotoEntities = photoData.entrySet().stream()
+			.map(entry -> ProductPhotoEntity.create(productId, entry.getValue(), entry.getKey()))
+			.collect(Collectors.toList());
+
+		List<ProductPhotoEntity> savedProductPhotoEntities = productPhotoRepository.saveAll(productPhotoEntities);
+
+		return savedProductPhotoEntities.stream()
+			.map(ProductPhoto::fromEntity)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/napzak/domain/product/core/ProductSaver.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductSaver.java
@@ -1,0 +1,44 @@
+package com.napzak.domain.product.core;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.napzak.domain.product.core.entity.ProductEntity;
+import com.napzak.domain.product.core.entity.enums.ProductCondition;
+import com.napzak.domain.product.core.entity.enums.TradeStatus;
+import com.napzak.domain.product.core.entity.enums.TradeType;
+import com.napzak.domain.product.core.vo.Product;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductSaver {
+	private final ProductRepository productRepository;
+
+	@Transactional
+	public Product save(
+		final String title,
+		final Long storeId,
+		final String description,
+		final TradeType tradeType,
+		final TradeStatus tradeStatus,
+		final int price,
+		final Boolean isPriceNegotiable,
+		final Boolean isDeliveryIncluded,
+		final int standardDeliveryFee,
+		final int halfDeliveryFee,
+		final ProductCondition productCondition,
+		final Long genreId
+	) {
+		final ProductEntity productEntity = productRepository.save(
+			ProductEntity.create(
+				title, storeId, description, tradeType, tradeStatus, price,
+				isPriceNegotiable, isDeliveryIncluded, standardDeliveryFee,
+				halfDeliveryFee, productCondition, genreId
+			)
+		);
+
+		return Product.fromEntity(productEntity);
+	}
+}

--- a/src/main/java/com/napzak/domain/product/core/entity/ProductEntity.java
+++ b/src/main/java/com/napzak/domain/product/core/entity/ProductEntity.java
@@ -64,7 +64,7 @@ public class ProductEntity {
 	private int halfDeliveryFee = 0;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = COLUMN_PRODUCT_CONDITION, nullable = false)
+	@Column(name = COLUMN_PRODUCT_CONDITION, nullable = true)
 	private ProductCondition productCondition;
 
 	@Column(name = COLUMN_INTEREST_COUNT, nullable = false)
@@ -77,11 +77,10 @@ public class ProductEntity {
 	private Long genreId;
 
 	@Builder
-	private ProductEntity(Long id, String title, String description, TradeType tradeType, int price,
+	private ProductEntity(String title, String description, TradeType tradeType, int price,
 		TradeStatus tradeStatus, Boolean isPriceNegotiable, Boolean isDeliveryIncluded,
 		int standardDeliveryFee, int halfDeliveryFee, ProductCondition productCondition,
 		Long storeId, Long genreId) {
-		this.id = id;
 		this.title = title;
 		this.description = description;
 		this.tradeType = tradeType;

--- a/src/main/java/com/napzak/domain/product/core/entity/ProductPhotoEntity.java
+++ b/src/main/java/com/napzak/domain/product/core/entity/ProductPhotoEntity.java
@@ -29,8 +29,7 @@ public class ProductPhotoEntity {
 	private int sequence;
 
 	@Builder
-	private ProductPhotoEntity(Long id, Long productId, String photoUrl, int sequence) {
-		this.id = id;
+	private ProductPhotoEntity(Long productId, String photoUrl, int sequence) {
 		this.productId = productId;
 		this.photoUrl = photoUrl;
 		this.sequence = sequence;

--- a/src/main/java/com/napzak/global/common/annotation/EnumValidator.java
+++ b/src/main/java/com/napzak/global/common/annotation/EnumValidator.java
@@ -1,0 +1,24 @@
+package com.napzak.global.common.annotation;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum<?>> {
+	private Set<String> validValues;
+
+	@Override
+	public void initialize(ValidEnum annotation) {
+		validValues = Arrays.stream(annotation.enumClass().getEnumConstants())
+			.map(Enum::name)
+			.collect(Collectors.toSet());
+	}
+
+	@Override
+	public boolean isValid(Enum<?> value, ConstraintValidatorContext context) {
+		return value != null && validValues.contains(value.name());
+	}
+}

--- a/src/main/java/com/napzak/global/common/annotation/ValidEnum.java
+++ b/src/main/java/com/napzak/global/common/annotation/ValidEnum.java
@@ -1,0 +1,19 @@
+package com.napzak.global.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumValidator.class)
+public @interface ValidEnum {
+	Class<? extends Enum<?>> enumClass();
+	String message() default "유효하지 않은 값입니다.";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/napzak/global/external/s3/api/controller/FileController.java
+++ b/src/main/java/com/napzak/global/external/s3/api/controller/FileController.java
@@ -1,0 +1,38 @@
+package com.napzak.global.external.s3.api.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.napzak.global.common.exception.dto.SuccessResponse;
+import com.napzak.global.external.s3.api.dto.ProductPresignedUrlFindAllResponse;
+import com.napzak.global.external.s3.api.service.FileService;
+import com.napzak.global.external.s3.exception.FileSuccessCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/presigned-url")
+@RequiredArgsConstructor
+public class FileController {
+
+	private final FileService fileService;
+
+	@GetMapping("/product")
+	public ResponseEntity<SuccessResponse<ProductPresignedUrlFindAllResponse>> generateAllPresignedUrls(
+		@RequestParam List<String> productImages) {
+		if (productImages == null || productImages.isEmpty()) {
+			throw new IllegalArgumentException("productImages 리스트는 비어 있을 수 없습니다.");
+		}
+
+		ProductPresignedUrlFindAllResponse response = fileService.generateAllPresignedUrlsForProduct(productImages);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(FileSuccessCode.PRESIGNED_URL_ISSUED, response)
+		);
+	}
+}

--- a/src/main/java/com/napzak/global/external/s3/api/dto/ProductPresignedUrlFindAllResponse.java
+++ b/src/main/java/com/napzak/global/external/s3/api/dto/ProductPresignedUrlFindAllResponse.java
@@ -1,0 +1,12 @@
+package com.napzak.global.external.s3.api.dto;
+
+import java.util.Map;
+
+public record ProductPresignedUrlFindAllResponse(
+	Map<String, String> productPresignedUrls
+) {
+	public static ProductPresignedUrlFindAllResponse from(
+		Map<String, String> productPresignedUrls) {
+		return new ProductPresignedUrlFindAllResponse(productPresignedUrls);
+	}
+}

--- a/src/main/java/com/napzak/global/external/s3/api/service/FileService.java
+++ b/src/main/java/com/napzak/global/external/s3/api/service/FileService.java
@@ -2,7 +2,10 @@ package com.napzak.global.external.s3.api.service;
 
 import java.net.URL;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -10,9 +13,12 @@ import org.springframework.stereotype.Service;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.napzak.global.external.s3.api.dto.ProductPresignedUrlFindAllResponse;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FileService {
@@ -27,12 +33,66 @@ public class FileService {
 	 *
 	 * @param prefix The folder/prefix where the file is stored.
 	 * @param fileName The name of the file.
-	 * @param method The HTTP method for the presigned URL (PUT or GET).
 	 * @return The generated presigned URL.
 	 */
-	public URL generatePresignedUrl(String prefix, String fileName, HttpMethod method) {
+	public URL generatePresignedUrl(String prefix, String fileName) {
 		String filePath = generatePath(prefix, fileName);
-		return amazonS3.generatePresignedUrl(buildPresignedUrlRequest(bucket, filePath, method));
+		return amazonS3.generatePresignedUrl(buildPresignedUrlRequest(bucket, filePath));
+	}
+
+	/**
+	 * 여러 상품 이미지 파일에 대한 Presigned URL 생성
+	 *
+	 * @param productImages 이미지 파일 이름 리스트
+	 * @return Presigned URL 매핑
+	 */
+	public ProductPresignedUrlFindAllResponse generateAllPresignedUrlsForProduct(List<String> productImages){
+		log.info("상품 Presigned URL 일괄 생성 요청 - 파일 수: {}", productImages.size());
+
+		Map<String, String> productPresignedUrls = productImages.parallelStream()
+			.collect(Collectors.toMap(
+				productImage -> productImage,
+				productImage -> {
+					String filePath = generatePath("product", productImage);
+					try {
+						URL presignedUrl = amazonS3.generatePresignedUrl(buildPresignedUrlRequest(bucket, filePath));
+						log.info("Presigned URL 생성 성공 - 파일명: {}", productImage);
+						return presignedUrl.toString();
+					} catch (Exception e) {
+						log.error("Presigned URL 생성 실패 - 파일명: {}, 오류: {}", productImage, e.getMessage());
+						throw new RuntimeException("S3 presigned URL 생성 중 오류 발생: " + e.getMessage());
+					}
+				}
+			));
+		log.info("모든 Presigned URL 생성 완료");
+
+		return ProductPresignedUrlFindAllResponse.from(productPresignedUrls);
+	}
+
+	/**
+	 * Build a presigned URL request for S3.
+	 *
+	 * @param bucket The S3 bucket name.
+	 * @param filePath The file path in the bucket.
+	 * @return The generated presigned URL request.
+	 */
+	private GeneratePresignedUrlRequest buildPresignedUrlRequest(String bucket, String filePath) {
+		return new GeneratePresignedUrlRequest(bucket, filePath)
+			.withMethod(HttpMethod.PUT)
+			.withExpiration(generatePresignedUrlExpiration());
+	}
+
+	/**
+	 * Generate the expiration date for the presigned URL (default 2 hours).
+	 *
+	 * @return The expiration date.
+	 */
+	private Date generatePresignedUrlExpiration() {
+		Date expiration = new Date();
+		long expTimeMillis = expiration.getTime();
+		expTimeMillis += 1000 * 60 * 60 * 2; // 2 hours
+		expiration.setTime(expTimeMillis);
+		return expiration;
 	}
 
 	/**
@@ -45,30 +105,5 @@ public class FileService {
 	private String generatePath(String prefix, String fileName) {
 		String fileId = UUID.randomUUID().toString();
 		return String.format("%s/%s-%s", prefix, fileId, fileName);
-	}
-
-	/**
-	 * Build a presigned URL request for S3.
-	 *
-	 * @param bucket The S3 bucket name.
-	 * @param filePath The file path in the bucket.
-	 * @param method The HTTP method (PUT or GET).
-	 * @return The generated presigned URL request.
-	 */
-	private GeneratePresignedUrlRequest buildPresignedUrlRequest(String bucket, String filePath, HttpMethod method) {
-		return new GeneratePresignedUrlRequest(bucket, filePath)
-			.withMethod(method)
-			.withExpiration(generatePresignedUrlExpiration());
-	}
-
-	/**
-	 * Generate the expiration date for the presigned URL (default 2 hours).
-	 *
-	 * @return The expiration date.
-	 */
-	private Date generatePresignedUrlExpiration() {
-		Date expiration = new Date();
-		expiration.setTime(expiration.getTime() + 1000 * 60 * 60 * 2); // 2 hours
-		return expiration;
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #72 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 구해요 상품 등록 api 구현
- 팔아요 상품 등록 api 구현
- presigned-url 발급 api 구현
- param enum값 검증하는 EnumValidator 추가
- 사진 sequence값 검증하는 SequenceValidator 추가
- entity builder에서 pk 제거
- ProductEntity의 productCondition 필드 nullable하게 수정(구해요에서는 null입니다!)

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 팔아요 상품 등록
<img width="720" alt="image" src="https://github.com/user-attachments/assets/ed296f18-5f39-419e-a7ca-10df2cbf8dc7" />
정상적으로 등록되는 것을 확인했고, @Valid 어노테이션 적용 여부도 확인했습니다. 원하는 예외 상황을 모두 잘 처리하고 있음을 확인했습니다.

### 구해요 상품 등록
<img width="739" alt="image" src="https://github.com/user-attachments/assets/fa6b932b-c34b-4872-ae07-68ff9b44860a" />
정상적으로 등록되는 것을 확인했고, @Valid 어노테이션 적용 여부도 확인했습니다. 원하는 예외 상황을 모두 잘 처리하고 있음을 확인했습니다.

### S3 presigned-url 발급
<img width="847" alt="스크린샷 2025-01-23 오전 1 00 44" src="https://github.com/user-attachments/assets/a96989ed-c114-40ef-985e-7d3552f26a34" />
정상적으로 발급됩니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
entity builder에서 pk 를 포함해서 빌드 하지 않습니다! 새로 entity를 만드는 것이기 때문에 나머지 필드들로 빌드하면 pk는 자동 등록됩니다~
