### PR TITLE
[fix] #121 - 홈화면 추천 상품 이슈 해결

### DIFF
--- a/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
@@ -116,7 +116,7 @@ public interface ProductApi {
 
 	@Operation(summary = "추천 상품 조회", description = "사용자의 관심 기반 추천 상품 조회")
 	@GetMapping("/home/recommend")
-	ResponseEntity<SuccessResponse<ProductListResponse>> getRecommendProducts(
+	ResponseEntity<SuccessResponse<ProductRecommendListResponse>> getRecommendProducts(
 		@CurrentMember Long currentStoreId
 	);
 

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductListResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductListResponse.java
@@ -1,9 +1,0 @@
-package com.napzak.domain.product.api.dto.response;
-
-import java.util.List;
-
-public record ProductListResponse(
-	List<ProductBuyDto> productBuyList,
-	List<ProductSellDto> productSellList
-) {
-}

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductRecommendListResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductRecommendListResponse.java
@@ -1,0 +1,32 @@
+package com.napzak.domain.product.api.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+import com.napzak.domain.product.api.service.ProductPagination;
+import com.napzak.global.common.util.TimeUtils;
+
+public record ProductRecommendListResponse(
+	List<ProductBuyDto> productRecommendList
+) {
+	public static ProductRecommendListResponse from(
+		ProductPagination pagination,
+		Map<Long, Boolean> interestMap,
+		Map<Long, String> genreMap,
+		Long currentStoreId
+	) {
+		List<ProductBuyDto> productDtos = pagination.getProductList().stream()
+			.map(product -> {
+				String uploadTime = TimeUtils.calculateUploadTime(product.getCreatedAt());
+				boolean isInterested = interestMap.getOrDefault(product.getId(), false);
+				String genreName = genreMap.getOrDefault(product.getGenreId(), "기타"); // genreName 매핑
+				boolean isOwnedByCurrentUser = currentStoreId.equals(product.getStoreId());
+
+				return ProductBuyDto.from(
+					product, uploadTime, isInterested, genreName, isOwnedByCurrentUser
+				);
+			}).toList();
+
+		return new ProductRecommendListResponse(productDtos);
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/service/ProductService.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductService.java
@@ -163,27 +163,10 @@ public class ProductService {
 		);
 	}
 
-	public ProductPagination searchRecommendBuyProducts(Long storeId, List<Long> genreIds) {
-
-		int size = 2;
-
+	public ProductPagination getHomeRecommendProducts(Long storeId, List<Long> genreIds) {
 		return retrieveAndPreparePagination(
-			() -> productRetriever.getRecommendedBuyProducts(
-				storeId, genreIds
-			),
-			size
-		);
-	}
-
-	public ProductPagination searchRecommendSellProducts(Long storeId, List<Long> genreIds) {
-
-		int size = 2;
-
-		return retrieveAndPreparePagination(
-			() -> productRetriever.getRecommendedSellProducts(
-				storeId, genreIds
-			),
-			size
+			() -> productRetriever.retrieveRecommendedProducts(storeId, genreIds),
+			4
 		);
 	}
 

--- a/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustom.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustom.java
@@ -12,13 +12,18 @@ public interface ProductRepositoryCustom {
 		Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType);
 
 	List<ProductEntity> searchProductsBySearchWordAndSortOptionAndFilters(
-		String searchWord, OrderSpecifier<?> orderSpecifier, Long cursorProductId, Integer cursorOptionalValue, int size,
-		Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType);
+		String searchWord, OrderSpecifier<?> orderSpecifier, Long cursorProductId, Integer cursorOptionalValue,
+		int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType);
 
 	List<ProductEntity> findProductsByStoreIdAndSortOptionAndFilters(
 		Long storeId, OrderSpecifier<?> orderSpecifier, Long cursorProductId, Integer cursorOptionalValue,
 		int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType);
 
 	List<ProductEntity> findProductsBySortOptionExcludingStoreId(
-			OrderSpecifier<?> orderSpecifier, int size, TradeType tradeType, long storeId);
+		OrderSpecifier<?> orderSpecifier, int size, TradeType tradeType, long storeId);
+
+	List<ProductEntity> findProductsByGenreAndTradeTypeExcludingStoreId(Long genreId, Long excludeStoreId,
+		TradeType tradeType, int limit);
+
+	List<ProductEntity> findLatestProductsExcludingStoreId(Long excludeStoreId, TradeType tradeType, int limit);
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustomImpl.java
@@ -94,6 +94,42 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 			.fetch();
 	}
 
+	/**
+	 * 본인 상품 제외 특정 장르의 상품을 가져오기 (SELL 또는 BUY)
+	 */
+	@Override
+	public List<ProductEntity> findProductsByGenreAndTradeTypeExcludingStoreId(Long genreId, Long excludeStoreId,
+		TradeType tradeType, int limit) {
+		return queryFactory
+			.selectFrom(productEntity)
+			.where(
+				productEntity.genreId.eq(genreId),               // 특정 장르 ID
+				productEntity.storeId.ne(excludeStoreId),        // 본인 상품 제외
+				productEntity.tradeType.eq(tradeType),           // SELL 또는 BUY 필터링
+				productEntity.tradeStatus.eq(TradeStatus.BEFORE_TRADE)  // 거래 가능 상태
+			)
+			.orderBy(productEntity.createdAt.desc())             // 최신순 정렬
+			.limit(limit)                                   // 원하는 개수만큼 조회
+			.fetch();
+	}
+
+	/**
+	 * 본인 상품 제외 최신 상품 가져오기 (전체 장르 대상)
+	 */
+	@Override
+	public List<ProductEntity> findLatestProductsExcludingStoreId(Long excludeStoreId, TradeType tradeType, int limit) {
+		return queryFactory
+			.selectFrom(productEntity)
+			.where(
+				productEntity.storeId.ne(excludeStoreId),  // 본인 상품 제외
+				productEntity.tradeType.eq(tradeType),     // SELL 또는 BUY 필터링
+				productEntity.tradeStatus.eq(TradeStatus.BEFORE_TRADE) // 거래 가능 상태
+			)
+			.orderBy(productEntity.createdAt.desc())       // 최신순 정렬
+			.limit(limit)                             // 원하는 개수만큼 조회
+			.fetch();
+	}
+
 	private BooleanExpression tradeTypeFilter(TradeType tradeType) {
 		if (tradeType != null) {
 			return productEntity.tradeType.eq(tradeType);

--- a/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
@@ -2,12 +2,12 @@ package com.napzak.domain.product.core;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ProductRetriever {
 
 	private final ProductRepository productRepository;
+	private static final List<Long> FALLBACK_GENRES = List.of(1L, 7L, 4L, 5L);
 
 	public boolean existsById(Long productId) {
 		return productRepository.existsById(productId);
@@ -67,7 +68,7 @@ public class ProductRetriever {
 			.map(Product::fromEntity)
 			.toList();
 	}
-	
+
 	public List<Product> searchProducts(String searchWord, SortOption sortOption, Long cursorProductId,
 		Integer cursorOptionalValue, int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds,
 		TradeType tradeType) {
@@ -77,80 +78,279 @@ public class ProductRetriever {
 			tradeType).stream().map(Product::fromEntity).toList();
 	}
 
-	//선호장르를 받아 선호장르 우선으로 buy product를 2개씩 구성. 부족하다면 default 장르에서 중복없이 가져오기.
-	public List<Product> getRecommendedBuyProducts(Long storeId, List<Long> genreIds) {
+	/**
+	 * 홈화면용 추천상품을 조회:
+	 *  - 선호 장르(각각 SELL2, BUY2) 모으기
+	 *  - 부족하면 fallback 장르, 최신 상품
+	 *  - 최종 2SELL+2BUY=4개
+	 *  - 장르를 최대한 다르게 구성(겹치지 않게)
+	 */
+	public List<Product> retrieveRecommendedProducts(Long storeId, List<Long> preferredGenres) {
+		// 1) 우선 선호 장르에서 최대한 수집
+		List<ProductEntity> collected = collectFromPreferredGenres(storeId, preferredGenres);
 
-		List<ProductEntity> products = getPreferenceProducts(genreIds, TradeType.BUY, storeId);
+		// 2) 2SELL+2BUY가 부족하면 fallback 장르에서 추가 수집
+		if (!isEnoughForSellBuy(collected, 2, 2)) {
+			collected = fillShortageWithFallback(storeId, collected, 2, 2);
+		}
 
-		return products.stream().map(Product::fromEntity).toList();
+		// 3) 여전히 부족하면 최신 상품
+		if (!isEnoughForSellBuy(collected, 2, 2)) {
+			collected = fillShortageWithLatest(storeId, collected, 2, 2);
+		}
+
+		// 4) 이제 collected 내에서 2SELL+2BUY=4개 조합을 모두 탐색,
+		//    "서로 다른 장르를 최대화"하는 조합을 고른다.
+		List<ProductEntity> best4 = pickBestFourMaxDistinctGenre(collected, 2, 2);
+
+		// 5) 만약 정말로 2SELL+2BUY가 불가능하면(리턴이 빈 리스트),
+		//    요구사항에 따라 반환값 변경 가능
+		//    우선은 "빈 리스트" 반환
+		if (best4.isEmpty()) {
+			return List.of();
+		}
+
+		// 6) SELL-BUY-SELL-BUY 순으로 정렬
+		best4 = reorderSellBuy(best4);
+
+		// 7) 엔티티 -> DTO 변환
+		return best4.stream().map(Product::fromEntity).toList();
 	}
 
-	//선호장르를 받아 선호장르 우선으로 sell product를 2개씩 구성. 부족하다면 default 장르에서 중복없이 가져오기.
-	public List<Product> getRecommendedSellProducts(Long storeId, List<Long> genreIds) {
-
-		Collections.reverse(genreIds);
-
-		List<ProductEntity> products = getPreferenceProducts(genreIds, TradeType.SELL, storeId);
-
-		return products.stream().map(Product::fromEntity).toList();
+	// ============================================================
+	// 1) 선호장르에서 수집: 장르마다 SELL 최대2, BUY 최대2
+	// ============================================================
+	private List<ProductEntity> collectFromPreferredGenres(Long storeId, List<Long> preferredGenres) {
+		List<ProductEntity> all = new ArrayList<>();
+		for (Long genreId : preferredGenres) {
+			// SELL 최대 2
+			List<ProductEntity> sells = productRepository.findProductsByGenreAndTradeTypeExcludingStoreId(
+				genreId, storeId, TradeType.SELL, 2
+			);
+			// BUY 최대 2
+			List<ProductEntity> buys = productRepository.findProductsByGenreAndTradeTypeExcludingStoreId(
+				genreId, storeId, TradeType.BUY, 2
+			);
+			all.addAll(sells);
+			all.addAll(buys);
+		}
+		return deduplicate(all);
 	}
 
-	public List<ProductEntity> getPreferenceProducts(List<Long> genreIds, TradeType tradeType, Long storeId) {
+	// ============================================================
+	// 2) fallback 장르에서 부족분 수집 (방법: 장르마다 SELL2, BUY2)
+	// ============================================================
+	private List<ProductEntity> fillShortageWithFallback(
+		Long storeId,
+		List<ProductEntity> collected,
+		int needSell,
+		int needBuy
+	) {
+		int shortageSell = needSell - countSell(collected);
+		int shortageBuy = needBuy - countBuy(collected);
 
-		//정렬 기준 : 최신순
-		Sort createdSort = Sort.by(Sort.Order.desc("createdAt"));
-		//정렬 기준 : 인기순
-		Sort interestSort = Sort.by(Sort.Order.desc("interestCount"));
+		// 이미 충족이면 그대로
+		if (shortageSell <= 0 && shortageBuy <= 0) {
+			return collected;
+		}
 
-		final List<Long> DEFAULT_GENRE_IDS = new ArrayList<>(List.of(1L, 7L, 4L, 5L));
-		Set<Long> addedProductIds = new HashSet<>(); // 추가된 상품의 ID를 추적하기 위한 Set
+		// fallback 장르 전부에서 SELL2 + BUY2
+		List<ProductEntity> fallbackAll = new ArrayList<>();
+		for (Long genreId : FALLBACK_GENRES) {
+			List<ProductEntity> sells = productRepository.findProductsByGenreAndTradeTypeExcludingStoreId(
+				genreId, storeId, TradeType.SELL, 2
+			);
+			List<ProductEntity> buys = productRepository.findProductsByGenreAndTradeTypeExcludingStoreId(
+				genreId, storeId, TradeType.BUY, 2
+			);
+			fallbackAll.addAll(sells);
+			fallbackAll.addAll(buys);
+		}
 
-		log.info("default 장르: {}", DEFAULT_GENRE_IDS);
-		log.info("선호 장르: {}", genreIds);
+		List<ProductEntity> merged = mergeWithoutDuplicates(collected, fallbackAll);
+		return merged;
+	}
 
-		List<ProductEntity> productEntityList = new ArrayList<>();
-		int productCount = 0;
+	// ============================================================
+	// 3) 최신 상품으로 부족분 보충 (SELL/BUY 각각 shortage만큼)
+	//    - 여기서는 "모든 장르"를 최신순으로 보되,
+	//      tradeType에 따라 shortage만큼
+	// ============================================================
+	private List<ProductEntity> fillShortageWithLatest(
+		Long storeId,
+		List<ProductEntity> collected,
+		int needSell,
+		int needBuy
+	) {
+		int shortageSell = needSell - countSell(collected);
+		int shortageBuy = needBuy - countBuy(collected);
 
-		//최대 4개 장르에서 가능한 대로 하나씩 가져옴.
-		for (int i = 0; i < 4; i++) {
-			for (Long g : genreIds) {
-				if (productCount >= 2) {
-					break;
-				}
+		if (shortageSell <= 0 && shortageBuy <= 0) {
+			return collected;
+		}
 
-				List<ProductEntity> product = productRepository.findTopByGenre(g, tradeType, storeId, 1, createdSort);
-				log.info("가져온 product: {}", product);
+		// 최신 SELL
+		List<ProductEntity> additionalSells = new ArrayList<>();
+		if (shortageSell > 0) {
+			// "최신 SELL"만 shortageSell개
+			additionalSells = productRepository.findLatestProductsExcludingStoreId(
+				storeId,
+				TradeType.SELL,
+				shortageSell
+			);
+		}
 
-				for (ProductEntity productEntity : product) {
-					if (!addedProductIds.contains(productEntity.getId())) {
-						productEntityList.add(productEntity);
-						addedProductIds.add(productEntity.getId());
-						productCount++;
-					}
-					if (productCount >= 2) {
-						break;
-					}
+		// 최신 BUY
+		List<ProductEntity> additionalBuys = new ArrayList<>();
+		if (shortageBuy > 0) {
+			additionalBuys = productRepository.findLatestProductsExcludingStoreId(
+				storeId,
+				TradeType.BUY,
+				shortageBuy
+			);
+		}
+
+		// 합치기
+		List<ProductEntity> merged = mergeWithoutDuplicates(collected, additionalSells);
+		merged = mergeWithoutDuplicates(merged, additionalBuys);
+		return merged;
+	}
+
+	// ============================================================
+	// 4) pickBestFourMaxDistinctGenre()
+	//    - collected 내에서 2SELL+2BUY=4개를 만드는 모든 조합 탐색
+	//    - "서로 다른 장르 수"가 최대가 되는 조합을 선택
+	//    - 여러 개라면 임의로 하나 선택 (혹은 다른 우선순위가 있다면 추가)
+	// ============================================================
+	private List<ProductEntity> pickBestFourMaxDistinctGenre(
+		List<ProductEntity> collected,
+		int needSell,
+		int needBuy
+	) {
+		// 우선 "2SELL+2BUY"를 만족하는 4개 부분집합을 전부 찾는다.
+		// 그중에서 "장르 수"가 최대인 조합을 반환.
+
+		if (collected.size() < 4) {
+			return Collections.emptyList();
+		}
+
+		// 부분집합을 찾기 위해, 간단히 "nC4"를 전수조사(브루트포스)하자.
+		// n이 20 이하 정도면 충분히 빠름.
+		List<ProductEntity> best = new ArrayList<>();
+		int maxDistinctGenres = -1;
+
+		List<List<ProductEntity>> allCombinations = combinationsOfSize(collected, 4);
+		for (List<ProductEntity> combo : allCombinations) {
+			long sellCount = combo.stream().filter(p -> p.getTradeType() == TradeType.SELL).count();
+			long buyCount = combo.stream().filter(p -> p.getTradeType() == TradeType.BUY).count();
+
+			if (sellCount == needSell && buyCount == needBuy) {
+				// 장르 중복 확인
+				long distinctGenreCount = combo.stream()
+					.map(ProductEntity::getGenreId)
+					.distinct()
+					.count();
+
+				if (distinctGenreCount > maxDistinctGenres) {
+					maxDistinctGenres = (int)distinctGenreCount;
+					best = combo; // 이 조합을 채택
 				}
 			}
-			log.info("현재 productEntityList: {}", productEntityList);
-			if (productCount >= 2) {
-				break;
+		}
+
+		// 만약 아무 조합도 없으면 빈 리스트
+		// 있으면 best 반환
+		return best;
+	}
+
+	// ============================================================
+	// 5) SELL-BUY-SELL-BUY 순서로 재정렬
+	//    (이미 2SELL,2BUY라고 가정)
+	// ============================================================
+	private List<ProductEntity> reorderSellBuy(List<ProductEntity> four) {
+		if (four.size() < 4)
+			return four; // 혹은 그냥 그대로
+
+		// SELL만 추출
+		List<ProductEntity> sells = four.stream()
+			.filter(p -> p.getTradeType() == TradeType.SELL)
+			.collect(Collectors.toList());
+
+		// BUY만 추출
+		List<ProductEntity> buys = four.stream()
+			.filter(p -> p.getTradeType() == TradeType.BUY)
+			.collect(Collectors.toList());
+
+		List<ProductEntity> result = new ArrayList<>();
+		for (int i = 0; i < Math.max(sells.size(), buys.size()); i++) {
+			if (i < sells.size())
+				result.add(sells.get(i));
+			if (i < buys.size())
+				result.add(buys.get(i));
+		}
+		return result;
+	}
+
+	// ============================================================
+	// [조합] nCk 구하기 (브루트포스)
+	// ============================================================
+	private List<List<ProductEntity>> combinationsOfSize(List<ProductEntity> list, int k) {
+		List<List<ProductEntity>> result = new ArrayList<>();
+		backtrack(list, 0, k, new ArrayList<>(), result);
+		return result;
+	}
+
+	private void backtrack(
+		List<ProductEntity> list,
+		int startIndex,
+		int k,
+		List<ProductEntity> current,
+		List<List<ProductEntity>> result
+	) {
+		if (current.size() == k) {
+			result.add(new ArrayList<>(current));
+			return;
+		}
+		for (int i = startIndex; i < list.size(); i++) {
+			current.add(list.get(i));
+			backtrack(list, i + 1, k, current, result);
+			current.remove(current.size() - 1);
+		}
+	}
+
+	// ============================================================
+	// 기타 보조 메서드
+	// ============================================================
+	private boolean isEnoughForSellBuy(List<ProductEntity> list, int needSell, int needBuy) {
+		return countSell(list) >= needSell && countBuy(list) >= needBuy;
+	}
+
+	private int countSell(List<ProductEntity> list) {
+		return (int)list.stream().filter(p -> p.getTradeType() == TradeType.SELL).count();
+	}
+
+	private int countBuy(List<ProductEntity> list) {
+		return (int)list.stream().filter(p -> p.getTradeType() == TradeType.BUY).count();
+	}
+
+	private List<ProductEntity> deduplicate(List<ProductEntity> list) {
+		// ID 기준 중복 제거
+		Map<Long, ProductEntity> map = new LinkedHashMap<>();
+		for (ProductEntity p : list) {
+			map.put(p.getId(), p);
+		}
+		return new ArrayList<>(map.values());
+	}
+
+	private List<ProductEntity> mergeWithoutDuplicates(List<ProductEntity> base, List<ProductEntity> extra) {
+		// base + extra 중복 제거
+		Set<Long> baseIds = base.stream().map(ProductEntity::getId).collect(Collectors.toSet());
+		List<ProductEntity> merged = new ArrayList<>(base);
+		for (ProductEntity e : extra) {
+			if (!baseIds.contains(e.getId())) {
+				merged.add(e);
 			}
 		}
-
-		if (productEntityList.size() > 2) {
-			productEntityList.sort(Comparator.comparing(ProductEntity::getCreatedAt).reversed());
-			productEntityList = productEntityList.subList(0, 2);
-		}
-
-		while (productCount < 2) {
-			productEntityList.addAll(
-				productRepository.findTopByGenre(DEFAULT_GENRE_IDS.get(0), tradeType, storeId, 1, interestSort));
-			DEFAULT_GENRE_IDS.remove(0);
-			productCount++;
-		}
-
-		log.info("최종 productEntityList: {}", productEntityList);
-		return productEntityList;
+		return merged;
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #121 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 기존에 buyList, sellList를 따로 반환했던 것과 달리 기획 요구사항에 맞게 팔아요-구해요-팔아요-구해요 순서로 한번에 반환하도록 response를 수정했습니다.

- buyList만 좋아요 여부를 잘못 불러오는 이슈가 있었는데, 코드를 살펴보니 interestMap을 buy 상품들만 조회해왔었습니다. buy, sell response를 합치면서 좋아요여부 잘못불러오는 이슈도 해결했습니다.

- 이전 코드 기준 유저의 선호장르/서버에서 지정한 장르의 상품이 없고, 기본 지정 장르의 상품도 없을 동일한 상품이 불러와지는 이슈가 있었습니다. 추천 상품 알고리즘의 문제라고 판단해 기존의 로직을 리팩토링했습니다. 코드의 주석으로 최대한 설명을 달아두었습니다!
    - 저의 구현 목표는 반드시 buy, sell 2개씩 불러오기, 선호 장르를 최대한 반영하며 다양한 장르를 불러오기, 기본 장르 상품도 없을 경우를 대비해 그 경우 최신 상품으로 보충하기였습니다. 부득이하게 조회 쿼리가 여러번 나가게 되었는데 추후 개선 방안을 좀 더 고민해보고 리팩토링 진행하면 좋을 것 같습니다!

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷
<!-- 관련 스크린샷을 첨부해주세요 -->
### 선호 장르가 없는 경우 -> 기본 장르에서 조회
<img width="725" alt="image" src="https://github.com/user-attachments/assets/2e4ef10d-1734-422b-9d05-a32637fdbf79" />

### 선호 장르가 1개인 경우 - 해당 장르에 상품이 없을 경우 -> 기본 장르에서 조회
<img width="734" alt="image" src="https://github.com/user-attachments/assets/ac59dc32-a968-49fe-8c88-774255218236" />

### 선호 장르가 1개인 경우 - 해당 장르에 상품이 부족할 경우 -> 선호장르 + 기본 장르에서 조회
<img width="734" alt="image" src="https://github.com/user-attachments/assets/f9a14b2f-0002-4e7b-9c93-65206477fdc2" />

선호장르 1개 상품과 기본장르 3개 상품 조회됨

### 선호 장르가 1개인 경우 - 해당 장르에 상품이 충분할 경우 -> 선호 장르로만 채움
<img width="729" alt="image" src="https://github.com/user-attachments/assets/1acbfa19-b582-446b-9d97-5ea7e4cd5edc" />

### 선호 장르가 2개인 경우 -> 둘을 적절히 섞어서 조회( 더 부족시 기본 장르에서 조회)
<img width="726" alt="image" src="https://github.com/user-attachments/assets/f1222ff4-a81b-442b-8516-40ca668f7f4d" />

1:3의 케이스

### 선호 장르가 3개인 경우 -> 모두 존재하면 1:1:2
<img width="744" alt="image" src="https://github.com/user-attachments/assets/25b84f1a-3fff-4938-b1b2-de24edfcad8c" />

### 선호 장르가 3개인 경우 -> 2개만 상품 존재하면 2 장르 조회하듯 가져옴
<img width="730" alt="image" src="https://github.com/user-attachments/assets/ddb2251c-60ad-4d49-af74-612dee12ae78" />

### 선호 장르가 4개인 경우 -> 모두 상품 존재하면 1:1:1:1로 조회
<img width="728" alt="image" src="https://github.com/user-attachments/assets/06ab1d53-8ec5-41e0-ad99-6daa0de40c4a" />

### 선호 장르가 4개인 경우 -> 상품 부족하면 3/2/1/0 장르의 상품 존재할 때 케이스로 조회
<img width="732" alt="image" src="https://github.com/user-attachments/assets/674a2eff-a7ef-48f4-9fad-68832595b7a4" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->
2개 장르의 상품 모두 넉넉할 경우 1:3으로 불러와지는 이슈 해결, 성능 개선 고민 필요합니다

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
