### PR TITLE
[feat]  #141 - AOP transaction 범위 추적

### DIFF
--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoSaver.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoSaver.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 public class ProductPhotoSaver {
 	private final ProductPhotoRepository productPhotoRepository;
 
-	@Transactional
 	public List<ProductPhoto> saveAll(final Long productId, final Map<Integer, String> photoData) {
 		List<ProductPhotoEntity> productPhotoEntities = photoData.entrySet().stream()
 			.map(entry -> ProductPhotoEntity.create(productId, entry.getValue(), entry.getKey()))

--- a/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
@@ -24,16 +24,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ProductRetriever {
 
 	private final ProductRepository productRepository;
 	private static final List<Long> FALLBACK_GENRES = List.of(1L, 7L, 4L, 5L);
 
+	@Transactional(readOnly = true)
 	public boolean existsById(Long productId) {
 		return productRepository.existsById(productId);
 	}
 
+	@Transactional(readOnly = true)
 	public Product findById(Long id) {
 		ProductEntity productEntity = productRepository.findById(id)
 			.orElseThrow(() -> new NapzakException(ProductErrorCode.PRODUCT_NOT_FOUND));
@@ -51,6 +52,7 @@ public class ProductRetriever {
 			.toList();
 	}
 
+	@Transactional(readOnly = true)
 	public List<Product> retrieveProductsExcludingCurrentUser(SortOption sortOption, int size, TradeType tradeType,
 		long storeId) {
 
@@ -58,6 +60,7 @@ public class ProductRetriever {
 			tradeType, storeId).stream().map(Product::fromEntity).toList();
 	}
 
+	@Transactional(readOnly = true)
 	public List<Product> retrieveStoreProducts(Long storeId, SortOption sortOption, Long cursorProductId,
 		Integer cursorOptionalValue, int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds,
 		TradeType tradeType) {
@@ -69,6 +72,7 @@ public class ProductRetriever {
 			.toList();
 	}
 
+	@Transactional(readOnly = true)
 	public List<Product> searchProducts(String searchWord, SortOption sortOption, Long cursorProductId,
 		Integer cursorOptionalValue, int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds,
 		TradeType tradeType) {
@@ -85,6 +89,7 @@ public class ProductRetriever {
 	 *  - 최종 2SELL+2BUY=4개
 	 *  - 장르를 최대한 다르게 구성(겹치지 않게)
 	 */
+	@Transactional(readOnly = true)
 	public List<Product> retrieveRecommendedProducts(Long storeId, List<Long> preferredGenres) {
 		// 1) 우선 선호 장르에서 최대한 수집
 		List<ProductEntity> collected = collectFromPreferredGenres(storeId, preferredGenres);

--- a/src/main/java/com/napzak/domain/product/core/ProductSaver.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductSaver.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 public class ProductSaver {
 	private final ProductRepository productRepository;
 
-	@Transactional
 	public Product save(
 		final String title,
 		final Long storeId,

--- a/src/main/java/com/napzak/domain/store/core/GenrePreferenceRetriever.java
+++ b/src/main/java/com/napzak/domain/store/core/GenrePreferenceRetriever.java
@@ -3,6 +3,7 @@ package com.napzak.domain.store.core;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.domain.store.core.entity.GenrePreferenceEntity;
 import com.napzak.domain.store.core.vo.GenrePreference;
@@ -15,6 +16,7 @@ public class GenrePreferenceRetriever {
 
 	private final GenrePreferenceRepository genrePreferenceRepository;
 
+	@Transactional(readOnly = true)
 	public List<GenrePreference> getGenrePreferences(Long storeId) {
 		List<GenrePreferenceEntity> genrePreferenceEntityList = genrePreferenceRepository.findByStoreId(storeId);
 		return genrePreferenceEntityList.stream()
@@ -22,10 +24,12 @@ public class GenrePreferenceRetriever {
 			.toList();
 	}
 
+	@Transactional(readOnly = true)
 	public boolean existsGenrePreference(Long storeId) {
 		return genrePreferenceRepository.existsByStoreId(storeId);
 	}
 
+	@Transactional(readOnly = true)
 	public List<Long> getGenrePreferenceIds(Long storeId) {
 		return genrePreferenceRepository.findGenreIdsByStoreId(storeId);
 	}

--- a/src/main/java/com/napzak/domain/store/core/StoreRetriever.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreRetriever.java
@@ -14,11 +14,11 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class StoreRetriever {
 
 	private final StoreRepository storeRepository;
 
+	@Transactional(readOnly = true)
 	public Store findStoreByStoreId(final Long id) {
 		StoreEntity storeEntity = storeRepository.findById(id)
 			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
@@ -26,22 +26,26 @@ public class StoreRetriever {
 		return Store.fromEntity((storeEntity));
 	}
 
+	@Transactional(readOnly = true)
 	public Store retrieveBySocialTypeAndSocialId(Long socialId, SocialType socialType) {
 		StoreEntity storeEntity = storeRepository.findBySocialTypeAndSocialId(socialId, socialType)
 			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
 		return Store.fromEntity(storeEntity);
 	}
 
+	@Transactional(readOnly = true)
 	public Store retrieveStoreByStoreId(Long StoreId) {
 		StoreEntity storeEntity = storeRepository.findById(StoreId)
 			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
 		return Store.fromEntity(storeEntity);
 	}
 
+	@Transactional(readOnly = true)
 	public boolean checkStoreExistsBySocialIdAndSocialType(final Long socialId, final SocialType socialType) {
 		return storeRepository.findBySocialTypeAndSocialId(socialId, socialType).isPresent();
 	}
 
+	@Transactional(readOnly = true)
 	public StoreStatusDto getStoreStatusDtoById(final Long storeId) {
 		return storeRepository.findStoreStatusById(storeId);
 	}

--- a/src/main/java/com/napzak/global/common/annotation/TransactionMonitoringAspect.java
+++ b/src/main/java/com/napzak/global/common/annotation/TransactionMonitoringAspect.java
@@ -1,0 +1,37 @@
+package com.napzak.global.common.annotation;
+
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@Order(0) // 트랜잭션보다 먼저 실행되도록 우선순위 설정
+public class TransactionMonitoringAspect {
+
+	@Pointcut("@annotation(org.springframework.transaction.annotation.Transactional)")
+	public void transactionalMethods() {}
+
+	@Around("transactionalMethods()")
+	public Object monitorTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+		log.info("트랜잭션 시작: {}", joinPoint.getSignature());
+
+		try {
+			Object result = joinPoint.proceed();
+			log.info("트랜잭션 성공: {}", joinPoint.getSignature());
+			return result;
+		} catch (Exception ex) {
+			log.error("트랜잭션 롤백 발생: {}, 예외: {}", joinPoint.getSignature(), ex.getMessage());
+			throw ex;
+		} finally {
+			log.info("트랜잭션 종료: {}", joinPoint.getSignature());
+		}
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #141 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
AOP transaction 범위 추적할 수 있도록 TransactionMonitoringAspect를 추가했습니다!
api 별로 정상적으로 트랜잭션 범위가 설정돼있는지 로그로 확인해보고 리팩토링하면 좋을 것 같습니다~
테스트 과정에서 예상보다 transaction이 많이 생기는 호출들을 발견해 일부 수정했는데 아직 더 수정 필요합니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
```
2025-01-24T22:54:55.341+09:00  INFO 84529 --- [nio-8080-exec-4] c.n.g.c.a.TransactionMonitoringAspect    : 트랜잭션 시작: boolean com.napzak.domain.interest.core.InterestRetriever.getIsInterested(Long,Long)
2025-01-24T22:54:55.400+09:00  INFO 84529 --- [nio-8080-exec-4] c.n.g.c.a.TransactionMonitoringAspect    : 트랜잭션 성공: boolean com.napzak.domain.interest.core.InterestRetriever.getIsInterested(Long,Long)
2025-01-24T22:54:55.400+09:00  INFO 84529 --- [nio-8080-exec-4] c.n.g.c.a.TransactionMonitoringAspect    : 트랜잭션 종료: boolean com.napzak.domain.interest.core.InterestRetriever.getIsInterested(Long,Long)
```
이런식으로 트랜잭션의 시작부터 종료까지 추적 가능하도록 로그가 나옵니다!

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
클래스 단위로 transactional 설정하면 aop로 추적이 안됩니다.
앞으로 메소드 단위로 붙이겠습니다!(ProductRetriever 쪽 변경사항 확인하시면 이해되실겁니다)